### PR TITLE
Update LibBlockAttributes to 0.4.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     modCompile("io.github.prospector.modmenu:ModMenu:${project.modmenu_version}") { transitive = false }
 //    modCompile "cotton:cotton:${project.cotton_version}"
     modCompile("io.github.cottonmc:cotton-energy:${project.energy_version}") { transitive = false }
-    modCompile("alexiil.mc.lib:libblockattributes:${project.attributes_version}") { transitive = false }
+    modCompile "alexiil.mc.lib:libblockattributes-items:${project.attributes_version}"
     modCompile("me.shedaniel:RoughlyEnoughItems:${project.rei_version}") { transitive = true }
 
     //include everything mandatory inside the jar
@@ -52,7 +52,10 @@ dependencies {
     include "io.github.prospector.silk:SilkAPI:${project.silk_version}"
 //    include "cotton:cotton:${project.cotton_version}"
     include "io.github.cottonmc:cotton-energy:${project.energy_version}"
-    include "alexiil.mc.lib:libblockattributes:${project.attributes_version}"
+    include "alexiil.mc.lib:libblockattributes-items:${project.attributes_version}"
+
+    // Needed for LBA in order for eclipse to work
+    compile "com.google.code.findbugs:jsr305:3.0.1"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,5 @@ org.gradle.jvmargs=-Xmx3G
     modmenu_version=1.6.2-92
     cotton_version=0.6.7+1.14.1
     energy_version=1.4.0+1.14.2-SNAPSHOT
-    attributes_version=0.4.5+build.1
+    attributes_version=0.4.5+build.2
     rei_version=2.9.4+build.129

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,5 @@ org.gradle.jvmargs=-Xmx3G
     modmenu_version=1.6.2-92
     cotton_version=0.6.7+1.14.1
     energy_version=1.4.0+1.14.2-SNAPSHOT
-    attributes_version=0.3.1
+    attributes_version=0.4.5+build.1
     rei_version=2.9.4+build.129

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,5 +22,5 @@ org.gradle.jvmargs=-Xmx3G
     modmenu_version=1.6.2-92
     cotton_version=0.6.7+1.14.1
     energy_version=1.4.0+1.14.2-SNAPSHOT
-    attributes_version=0.4.5+build.2
+    attributes_version=0.4.5
     rei_version=2.9.4+build.129

--- a/src/main/java/com/hrznstudio/galacticraft/GalacticraftClient.java
+++ b/src/main/java/com/hrznstudio/galacticraft/GalacticraftClient.java
@@ -65,9 +65,9 @@ public class GalacticraftClient implements ClientModInitializer {
 
         ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.PLAYER_INVENTORY_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new PlayerInventoryGCScreen(playerEntity));
 
-        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.COAL_GENERATOR_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new CoalGeneratorScreen(syncId, packetByteBuf.readBlockPos(), playerEntity));
-        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.BASIC_SOLAR_PANEL_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new BasicSolarPanelScreen(syncId, packetByteBuf.readBlockPos(), playerEntity));
-        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.CIRCUIT_FABRICATOR_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new CircuitFabricatorScreen(syncId, packetByteBuf.readBlockPos(), playerEntity));
+        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.COAL_GENERATOR_CONTAINER, CoalGeneratorScreen.FACTORY);
+        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.BASIC_SOLAR_PANEL_CONTAINER, BasicSolarPanelScreen.FACTORY);
+        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.CIRCUIT_FABRICATOR_CONTAINER, CircuitFabricatorScreen.FACTORY);
         ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.COMPRESSOR_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new CompressorScreen(syncId, packetByteBuf.readBlockPos(), playerEntity));
         ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.ELECTRIC_COMPRESSOR_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new ElectricCompressorScreen(syncId, packetByteBuf.readBlockPos(), playerEntity));
         ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.ENERGY_STORAGE_MODULE_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new EnergyStorageModuleScreen(syncId, packetByteBuf.readBlockPos(), playerEntity));

--- a/src/main/java/com/hrznstudio/galacticraft/GalacticraftClient.java
+++ b/src/main/java/com/hrznstudio/galacticraft/GalacticraftClient.java
@@ -68,10 +68,10 @@ public class GalacticraftClient implements ClientModInitializer {
         ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.COAL_GENERATOR_CONTAINER, CoalGeneratorScreen.FACTORY);
         ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.BASIC_SOLAR_PANEL_CONTAINER, BasicSolarPanelScreen.FACTORY);
         ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.CIRCUIT_FABRICATOR_CONTAINER, CircuitFabricatorScreen.FACTORY);
-        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.COMPRESSOR_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new CompressorScreen(syncId, packetByteBuf.readBlockPos(), playerEntity));
-        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.ELECTRIC_COMPRESSOR_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new ElectricCompressorScreen(syncId, packetByteBuf.readBlockPos(), playerEntity));
-        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.ENERGY_STORAGE_MODULE_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new EnergyStorageModuleScreen(syncId, packetByteBuf.readBlockPos(), playerEntity));
-        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.OXYGEN_COLLECTOR_CONTAINER, (syncId, identifier, playerEntity, packetByteBuf) -> new OxygenCollectorScreen(syncId, packetByteBuf.readBlockPos(), playerEntity));
+        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.COMPRESSOR_CONTAINER, CompressorScreen.FACTORY);
+        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.ELECTRIC_COMPRESSOR_CONTAINER, ElectricCompressorScreen.ELECTRIC_FACTORY);
+        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.ENERGY_STORAGE_MODULE_CONTAINER, EnergyStorageModuleScreen.FACTORY);
+        ScreenProviderRegistry.INSTANCE.registerFactory(GalacticraftContainers.OXYGEN_COLLECTOR_CONTAINER, OxygenCollectorScreen.FACTORY);
 
         EntityRendererRegistry.INSTANCE.register(T1RocketEntity.class, (manager, context) -> new RocketEntityRenderer(manager));
         GalacticraftBlockEntityRenderers.register();

--- a/src/main/java/com/hrznstudio/galacticraft/api/item/EnergyHolderItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/item/EnergyHolderItem.java
@@ -4,6 +4,10 @@ import com.hrznstudio.galacticraft.energy.GalacticraftEnergy;
 import net.minecraft.item.ItemStack;
 
 public interface EnergyHolderItem {
+
+    /** @return The maximum energy that the given {@link ItemStack} can store. */
+    int getMaxEnergy(ItemStack battery);
+
     /**
      * If this is overridden to return true, energy will always be extracted and inserting of energy will be denied.
      *

--- a/src/main/java/com/hrznstudio/galacticraft/api/screen/MachineContainerScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/screen/MachineContainerScreen.java
@@ -1,19 +1,28 @@
 package com.hrznstudio.galacticraft.api.screen;
 
 import com.hrznstudio.galacticraft.Constants;
+import com.hrznstudio.galacticraft.blocks.machines.MachineBlockEntity;
+import com.hrznstudio.galacticraft.blocks.machines.MachineContainer;
+import com.hrznstudio.galacticraft.blocks.machines.MachineContainer.MachineContainerConstructor;
+
+import net.fabricmc.fabric.api.container.ContainerFactory;
+
 import net.minecraft.ChatFormat;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.client.gui.screen.ingame.AbstractContainerScreen;
 import net.minecraft.client.resource.language.I18n;
 import net.minecraft.container.Container;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.network.chat.BaseComponent;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockPos;
 
 /**
  * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
  */
-public abstract class MachineContainerScreen extends AbstractContainerScreen {
+public abstract class MachineContainerScreen<C extends MachineContainer<?>> extends AbstractContainerScreen<C> {
 
     public static final Identifier TABS_TEXTURE = new Identifier(Constants.MOD_ID, Constants.ScreenTextures.getRaw(Constants.ScreenTextures.MACHINE_CONFIG_TABS));
     public static final Identifier PANELS_TEXTURE = new Identifier(Constants.MOD_ID, Constants.ScreenTextures.getRaw(Constants.ScreenTextures.MACHINE_CONFIG_PANELS));
@@ -30,8 +39,22 @@ public abstract class MachineContainerScreen extends AbstractContainerScreen {
 
     public static boolean IS_CONFIG_OPEN = false;
 
-    public MachineContainerScreen(Container container, PlayerInventory playerInventory, TextComponent textComponent) {
+    public MachineContainerScreen(C container, PlayerInventory playerInventory, BaseComponent textComponent) {
         super(container, playerInventory, textComponent);
+    }
+
+    public static <T extends MachineBlockEntity> ContainerFactory<AbstractContainerScreen> createFactory(
+        Class<T> machineClass, MachineContainerConstructor<? extends MachineContainerScreen<?>, T> constructor) 
+    {
+        return (syncId, id, player, buffer) -> {
+            BlockPos pos = buffer.readBlockPos();
+            BlockEntity be = player.world.getBlockEntity(pos);
+            if (machineClass.isInstance(be)) {
+                return constructor.create(syncId, player, machineClass.cast(be));
+            } else {
+                return null;
+            }
+        };
     }
 
     public void drawConfigTabs() {

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/MachineBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/MachineBlockEntity.java
@@ -1,6 +1,11 @@
 package com.hrznstudio.galacticraft.blocks.machines;
 
 import alexiil.mc.lib.attributes.Simulation;
+import alexiil.mc.lib.attributes.item.LimitedFixedItemInv;
+import alexiil.mc.lib.attributes.item.FixedItemInv;
+import alexiil.mc.lib.attributes.item.ItemInvSlotChangeListener.ItemInvSlotListener;
+import alexiil.mc.lib.attributes.item.filter.ConstantItemFilter;
+import alexiil.mc.lib.attributes.item.filter.ItemFilter;
 import alexiil.mc.lib.attributes.item.impl.SimpleFixedItemInv;
 import com.hrznstudio.galacticraft.api.item.EnergyHolderItem;
 import com.hrznstudio.galacticraft.energy.GalacticraftEnergy;
@@ -16,12 +21,26 @@ import net.minecraft.nbt.CompoundTag;
  */
 public abstract class MachineBlockEntity extends BlockEntity implements BlockEntityClientSerializable {
     public static final int DEFAULT_MAX_ENERGY = 15000;
-    public SimpleEnergyAttribute energy = new SimpleEnergyAttribute(getMaxEnergy(), GalacticraftEnergy.GALACTICRAFT_JOULES);
-    private SimpleFixedItemInv inventory = new SimpleFixedItemInv(getInvSize());
+    public final SimpleEnergyAttribute energy = new SimpleEnergyAttribute(getMaxEnergy(), GalacticraftEnergy.GALACTICRAFT_JOULES);
+    private final SimpleFixedItemInv inventory = new SimpleFixedItemInv(getInvSize()) {
+
+        @Override
+        public boolean isItemValidForSlot(int slot, ItemStack item) {
+            return getFilterForSlot(slot).matches(item);
+        }
+
+        @Override
+        public ItemFilter getFilterForSlot(int slot) {
+            return MachineBlockEntity.this.getFilterForSlot(slot);
+        }
+    };
+    private final LimitedFixedItemInv limitedInventory = inventory.createLimitedFixedInv();
+    private final FixedItemInv exposedInventory = limitedInventory.asUnmodifiable();
 
     public MachineBlockEntity(BlockEntityType<?> blockEntityType) {
         super(blockEntityType);
         this.energy.listen(this::markDirty);
+        this.inventory.setOwnerListener((ItemInvSlotListener) (inv, slot) -> markDirty());
     }
 
     /**
@@ -33,20 +52,61 @@ public abstract class MachineBlockEntity extends BlockEntity implements BlockEnt
         return DEFAULT_MAX_ENERGY;
     }
 
+    /** @return The {@link ItemFilter} for the given slot of {@link #getInventory()}. */
+    protected ItemFilter getFilterForSlot(int slot) {
+        return ConstantItemFilter.ANYTHING;
+    }
+
+    /** @return The maximum amount of energy that can be transfered to or from a battery in this machine per call to
+     *         {@link #attemptChargeFromStack(int)} or {@link #attemptDrainPowerToStack(int)} */
+    protected int getBatteryTransferRate() {
+        return 20;
+    }
+
     public SimpleEnergyAttribute getEnergy() {
         return energy;
     }
 
-    // Tries charging the block entity with the given itemstack
-    protected void attemptChargeFromStack(ItemStack battery) {
-        if (GalacticraftEnergy.isEnergyItem(battery)) {
-            int itemEnergy = GalacticraftEnergy.getBatteryEnergy(battery);
-            EnergyHolderItem item = (EnergyHolderItem) battery.getItem();
+    /**
+     * Tries to charge this machine from the item in the given slot in this {@link #getInventory}.
+     */
+    protected void attemptChargeFromStack(int slot) {
+        if (energy.getCurrentEnergy() >= energy.getMaxEnergy()) {
+            return;
+        }
+        ItemStack stack = inventory.getInvStack(slot);
+        if (GalacticraftEnergy.isEnergyItem(stack)) {
+            int itemEnergy = GalacticraftEnergy.getBatteryEnergy(stack);
+            EnergyHolderItem item = (EnergyHolderItem) stack.getItem();
 
-            if (itemEnergy > 0 && energy.getCurrentEnergy() < energy.getMaxEnergy()) {
+            if (itemEnergy > 0) {
+                stack = stack.copy();
                 int energyToRemove = 5;
-                int amountFailedToInsert = item.extract(battery, energyToRemove);
+                int amountFailedToInsert = item.extract(stack, energyToRemove);
                 energy.insertEnergy(GalacticraftEnergy.GALACTICRAFT_JOULES, energyToRemove - amountFailedToInsert, Simulation.ACTION);
+                inventory.forceSetInvStack(slot, stack);
+            }
+        }
+    }
+
+    /**
+     * Tries to drain some of this machine's power into the item in the given slot in this {@link #getInventory}.
+     */
+    protected void attemptDrainPowerToStack(int slot) {
+        int available = Math.min(getBatteryTransferRate(), energy.getCurrentEnergy());
+        if (available <= 0) {
+            return;
+        }
+        ItemStack stack = inventory.getInvStack(slot);
+        if (GalacticraftEnergy.isEnergyItem(stack)) {
+            int itemEnergy = GalacticraftEnergy.getBatteryEnergy(stack);
+            int itemMaxEnergy = GalacticraftEnergy.getMaxBatteryEnergy(stack);
+            EnergyHolderItem item = (EnergyHolderItem) stack.getItem();
+            if (itemEnergy < itemMaxEnergy) {
+                stack = stack.copy();
+                int leftover = item.insert(stack, available);
+                energy.extractEnergy(GalacticraftEnergy.GALACTICRAFT_JOULES, available - leftover, Simulation.ACTION);
+                inventory.forceSetInvStack(slot, stack);
             }
         }
     }
@@ -55,6 +115,17 @@ public abstract class MachineBlockEntity extends BlockEntity implements BlockEnt
 
     public final SimpleFixedItemInv getInventory() {
         return inventory;
+    }
+
+    /** @return A {@link LimitedFixedItemInv} that can be used to limit what neighbouring blocks do with the
+     *         {@link #getExposedInventory() exposed inventory}. */
+    public final LimitedFixedItemInv getLimitedInventory() {
+        return limitedInventory;
+    }
+
+    /** @return The {@link FixedItemInv} that is exposed to neighbouring blocks via attributes. */
+    public final FixedItemInv getExposedInventory() {
+        return exposedInventory;
     }
 
     @Override

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/MachineContainer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/MachineContainer.java
@@ -1,0 +1,53 @@
+package com.hrznstudio.galacticraft.blocks.machines;
+
+import net.fabricmc.fabric.api.container.ContainerFactory;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.container.Container;
+import net.minecraft.container.Property;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+
+public abstract class MachineContainer<T extends MachineBlockEntity> extends Container {
+
+    @FunctionalInterface
+    public interface MachineContainerConstructor<C, T> {
+        C create(int syncId, PlayerEntity player, T blockEntity);
+    }
+
+    public final PlayerEntity playerEntity;
+    public final T blockEntity;
+
+    public final Property energy = Property.create();
+
+    protected MachineContainer(int syncId, PlayerEntity playerEntity, T blockEntity) {
+        super(null, syncId);
+        this.playerEntity = playerEntity;
+        this.blockEntity = blockEntity;
+        addProperty(energy);
+    }
+
+    public static <C extends MachineContainer<T>, T extends MachineBlockEntity> ContainerFactory<Container> createFactory(
+        Class<T> machineClass, MachineContainerConstructor<C, T> constructor) 
+    {
+        return (syncId, id, player, buffer) -> {
+            BlockPos pos = buffer.readBlockPos();
+            BlockEntity be = player.world.getBlockEntity(pos);
+            if (machineClass.isInstance(be)) {
+                return constructor.create(syncId, player, machineClass.cast(be));
+            } else {
+                return null;
+            }
+        };
+    }
+
+    @Override
+    public void sendContentUpdates() {
+        energy.set(blockEntity.getEnergy().getCurrentEnergy());
+        super.sendContentUpdates();
+    }
+
+    public int getMaxEnergy() {
+        return blockEntity.getMaxEnergy();
+    }
+}

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/MachineContainer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/MachineContainer.java
@@ -27,8 +27,8 @@ public abstract class MachineContainer<T extends MachineBlockEntity> extends Con
         addProperty(energy);
     }
 
-    public static <C extends MachineContainer<T>, T extends MachineBlockEntity> ContainerFactory<Container> createFactory(
-        Class<T> machineClass, MachineContainerConstructor<C, T> constructor) 
+    public static <T extends MachineBlockEntity> ContainerFactory<Container> createFactory(
+        Class<T> machineClass, MachineContainerConstructor<? extends Container, T> constructor) 
     {
         return (syncId, id, player, buffer) -> {
             BlockPos pos = buffer.readBlockPos();

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelBlock.java
@@ -92,7 +92,7 @@ public class BasicSolarPanelBlock extends BlockWithEntity implements AttributePr
         BasicSolarPanelBlockEntity generator = (BasicSolarPanelBlockEntity) be;
         to.offer(generator.getEnergy());
         to.offer(generator);
-//        generator.getItems().offerSelfAsAttribute(to, null, null);
+        generator.getExposedInventory().offerSelfAsAttribute(to, null, null);
     }
 
     @Override

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelBlockEntity.java
@@ -1,8 +1,8 @@
 package com.hrznstudio.galacticraft.blocks.machines.basicsolarpanel;
 
-import alexiil.mc.lib.attributes.DefaultedAttribute;
-import alexiil.mc.lib.attributes.SearchOptions;
 import alexiil.mc.lib.attributes.Simulation;
+import alexiil.mc.lib.attributes.item.filter.ItemFilter;
+
 import com.google.common.collect.Lists;
 import com.hrznstudio.galacticraft.api.configurable.SideOptions;
 import com.hrznstudio.galacticraft.blocks.machines.MachineBlockEntity;
@@ -10,7 +10,6 @@ import com.hrznstudio.galacticraft.energy.GalacticraftEnergy;
 import com.hrznstudio.galacticraft.entity.GalacticraftBlockEntities;
 import com.hrznstudio.galacticraft.util.BlockOptionUtils;
 import io.github.cottonmc.energy.api.EnergyAttribute;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.Tickable;
 import net.minecraft.util.math.Direction;
 
@@ -37,6 +36,11 @@ public class BasicSolarPanelBlockEntity extends MachineBlockEntity implements Ti
     @Override
     protected int getInvSize() {
         return 1;
+    }
+
+    @Override
+    protected ItemFilter getFilterForSlot(int slot) {
+        return GalacticraftEnergy.ENERGY_HOLDER_ITEM_FILTER;
     }
 
     @Override
@@ -74,17 +78,11 @@ public class BasicSolarPanelBlockEntity extends MachineBlockEntity implements Ti
         }
         if (world.isClient) return;
 
-        ItemStack battery = getInventory().getInvStack(0);
-        if (GalacticraftEnergy.isEnergyItem(battery) && this.getEnergy().getCurrentEnergy() > 0) {
-            if (GalacticraftEnergy.getBatteryEnergy(battery) < GalacticraftEnergy.getMaxBatteryEnergy(battery)) {
-                getEnergy().extractEnergy(GalacticraftEnergy.GALACTICRAFT_JOULES, 1, Simulation.ACTION);
-                GalacticraftEnergy.incrementEnergy(battery, 1);
-            }
-        }
+        attemptDrainPowerToStack(0);
 
         for (Direction direction : Direction.values()) {
             if (selectedOptions.get(direction).equals(SideOptions.POWER_OUTPUT)) {
-                EnergyAttribute energyAttribute = getNeighborAttribute(EnergyAttribute.ENERGY_ATTRIBUTE, direction);
+                EnergyAttribute energyAttribute = EnergyAttribute.ENERGY_ATTRIBUTE.getFirstFromNeighbour(this, direction);
                 if (energyAttribute.canInsertEnergy()) {
                     this.getEnergy().setCurrentEnergy(energyAttribute.insertEnergy(GalacticraftEnergy.GALACTICRAFT_JOULES, 1, Simulation.ACTION));
                 }
@@ -93,8 +91,9 @@ public class BasicSolarPanelBlockEntity extends MachineBlockEntity implements Ti
 
     }
 
-    public <T> T getNeighborAttribute(DefaultedAttribute<T> attr, Direction dir) {
-        return attr.getFirst(getWorld(), getPos().offset(dir), SearchOptions.inDirection(dir));
+    @Override
+    protected int getBatteryTransferRate() {
+        return 10;
     }
 
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelBlockEntity.java
@@ -45,6 +45,9 @@ public class BasicSolarPanelBlockEntity extends MachineBlockEntity implements Ti
 
     @Override
     public void tick() {
+        if (world.isClient) {
+            return;
+        }
         long time = world.getTimeOfDay();
         while (true) {
             if (time <= -1) {
@@ -54,18 +57,15 @@ public class BasicSolarPanelBlockEntity extends MachineBlockEntity implements Ti
             time -= 24000;
         }
 
-        if ((time > 250 && time < 12000)) {
-            if (getEnergy().getCurrentEnergy() <= getEnergy().getMaxEnergy()) {
+        if (world.isRaining() || world.isThundering()) {
+            status = BasicSolarPanelStatus.RAINING;
+        } else if ((time > 250 && time < 12000)) {
+            if (getEnergy().getCurrentEnergy() < getEnergy().getMaxEnergy()) {
                 status = BasicSolarPanelStatus.COLLECTING;
             } else {
-                getEnergy().setCurrentEnergy(getEnergy().getMaxEnergy());
                 status = BasicSolarPanelStatus.FULL;
             }
-        } else if (world.isRaining() || world.isThundering()) {
-            status = BasicSolarPanelStatus.RAINING;
-        }
-
-        if (time <= 250 || time >= 12000) {
+        } else {
             status = BasicSolarPanelStatus.NIGHT;
         }
 
@@ -76,7 +76,6 @@ public class BasicSolarPanelBlockEntity extends MachineBlockEntity implements Ti
                 getEnergy().insertEnergy(GalacticraftEnergy.GALACTICRAFT_JOULES, (int) (((double) time / 133.3333333333D)), Simulation.ACTION);
             }
         }
-        if (world.isClient) return;
 
         attemptDrainPowerToStack(0);
 

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelContainer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelContainer.java
@@ -1,8 +1,15 @@
 package com.hrznstudio.galacticraft.blocks.machines.basicsolarpanel;
 
-import alexiil.mc.lib.attributes.item.impl.PartialInventoryFixedWrapper;
+import alexiil.mc.lib.attributes.item.compat.InventoryFixedWrapper;
+
+import com.hrznstudio.galacticraft.blocks.machines.MachineContainer;
+import com.hrznstudio.galacticraft.blocks.machines.coalgenerator.CoalGeneratorBlockEntity;
+import com.hrznstudio.galacticraft.blocks.machines.coalgenerator.CoalGeneratorContainer;
 import com.hrznstudio.galacticraft.container.slot.ItemSpecificSlot;
 import com.hrznstudio.galacticraft.items.GalacticraftItems;
+
+import net.fabricmc.fabric.api.container.ContainerFactory;
+
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.container.Container;
 import net.minecraft.container.Slot;
@@ -14,30 +21,17 @@ import net.minecraft.util.math.BlockPos;
 /**
  * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
  */
-public class BasicSolarPanelContainer extends Container {
+public class BasicSolarPanelContainer extends MachineContainer<BasicSolarPanelBlockEntity> {
+
+    public static final ContainerFactory<Container> FACTORY = createFactory(BasicSolarPanelBlockEntity.class, BasicSolarPanelContainer::new);
+
     private final Inventory inventory;
-    private BlockPos blockPos;
     private BasicSolarPanelBlockEntity solarPanel;
-    private PlayerEntity playerEntity;
 
-    public BasicSolarPanelContainer(int syncId, BlockPos blockPos, PlayerEntity playerEntity) {
-        super(null, syncId);
-        this.blockPos = blockPos;
-        this.playerEntity = playerEntity;
-
-        BlockEntity blockEntity = playerEntity.world.getBlockEntity(blockPos);
-
-        if (!(blockEntity instanceof BasicSolarPanelBlockEntity)) {
-            // TODO: Move this logic somewhere else to just not open this at all.
-            throw new IllegalStateException("Found " + blockEntity + " instead of a solar panel!");
-        }
-        this.solarPanel = (BasicSolarPanelBlockEntity) blockEntity;
-        this.inventory = new PartialInventoryFixedWrapper(solarPanel.getInventory()) {
-            @Override
-            public void markDirty() {
-                solarPanel.markDirty();
-            }
-
+    public BasicSolarPanelContainer(int syncId, PlayerEntity playerEntity, BasicSolarPanelBlockEntity blockEntity) {
+        super(syncId, playerEntity, blockEntity);
+        this.solarPanel = blockEntity;
+        this.inventory = new InventoryFixedWrapper(solarPanel.getInventory()) {
             @Override
             public boolean canPlayerUseInv(PlayerEntity player) {
                 return BasicSolarPanelContainer.this.canUse(player);
@@ -91,5 +85,4 @@ public class BasicSolarPanelContainer extends Container {
     public boolean canUse(PlayerEntity playerEntity) {
         return true;
     }
-
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelContainer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelContainer.java
@@ -12,6 +12,7 @@ import net.fabricmc.fabric.api.container.ContainerFactory;
 
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.container.Container;
+import net.minecraft.container.Property;
 import net.minecraft.container.Slot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
@@ -28,6 +29,8 @@ public class BasicSolarPanelContainer extends MachineContainer<BasicSolarPanelBl
     private final Inventory inventory;
     private BasicSolarPanelBlockEntity solarPanel;
 
+    private final Property status = Property.create();
+
     public BasicSolarPanelContainer(int syncId, PlayerEntity playerEntity, BasicSolarPanelBlockEntity blockEntity) {
         super(syncId, playerEntity, blockEntity);
         this.solarPanel = blockEntity;
@@ -37,6 +40,7 @@ public class BasicSolarPanelContainer extends MachineContainer<BasicSolarPanelBl
                 return BasicSolarPanelContainer.this.canUse(player);
             }
         };
+        addProperty(status);
 
         this.addSlot(new ItemSpecificSlot(this.inventory, 0, 8, 53, GalacticraftItems.BATTERY));
 
@@ -84,5 +88,17 @@ public class BasicSolarPanelContainer extends MachineContainer<BasicSolarPanelBl
     @Override
     public boolean canUse(PlayerEntity playerEntity) {
         return true;
+    }
+
+    @Override
+    public void sendContentUpdates() {
+        status.set(blockEntity.status.ordinal());
+        super.sendContentUpdates();
+    }
+
+    @Override
+    public void setProperties(int index, int value) {
+        super.setProperties(index, value);
+        blockEntity.status = BasicSolarPanelStatus.get(status.get());
     }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelScreen.java
@@ -1,16 +1,19 @@
 package com.hrznstudio.galacticraft.blocks.machines.basicsolarpanel;
 
 import com.hrznstudio.galacticraft.Constants;
+import com.hrznstudio.galacticraft.api.screen.MachineContainerScreen;
 import com.hrznstudio.galacticraft.energy.GalacticraftEnergyType;
 import com.hrznstudio.galacticraft.util.DrawableUtils;
 import com.mojang.blaze3d.platform.GlStateManager;
+
+import net.fabricmc.fabric.api.container.ContainerFactory;
+
 import net.minecraft.ChatFormat;
 import net.minecraft.client.gui.screen.ingame.AbstractContainerScreen;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.chat.Style;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import java.util.ArrayList;
@@ -19,7 +22,9 @@ import java.util.List;
 /**
  * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
  */
-public class BasicSolarPanelScreen extends AbstractContainerScreen {
+public class BasicSolarPanelScreen extends MachineContainerScreen<BasicSolarPanelContainer> {
+
+    public static final ContainerFactory<AbstractContainerScreen> FACTORY = createFactory(BasicSolarPanelBlockEntity.class, BasicSolarPanelScreen::new);
 
     private static final Identifier BACKGROUND = new Identifier(Constants.MOD_ID, Constants.ScreenTextures.getRaw(Constants.ScreenTextures.BASIC_SOLAR_PANEL_SCREEN));
     private static final Identifier CONFIG_TABS = new Identifier(Constants.MOD_ID, Constants.ScreenTextures.getRaw(Constants.ScreenTextures.MACHINE_CONFIG_TABS));
@@ -37,14 +42,12 @@ public class BasicSolarPanelScreen extends AbstractContainerScreen {
     private static final int CONFIG_TAB_Y = 69;
     private static final int CONFIG_TAB_WIDTH = 22;
     private static final int CONFIG_TAB_HEIGHT = 22;
-    BlockPos blockPos;
     private int energyDisplayX = 0;
     private int energyDisplayY = 0;
     private World world;
 
-    public BasicSolarPanelScreen(int syncId, BlockPos blockPos, PlayerEntity playerEntity) {
-        super(new BasicSolarPanelContainer(syncId, blockPos, playerEntity), playerEntity.inventory, new TranslatableComponent("ui.galacticraft-rewoven.basic_solar_panel.name"));
-        this.blockPos = blockPos;
+    public BasicSolarPanelScreen(int syncId, PlayerEntity playerEntity, BasicSolarPanelBlockEntity blockEntity) {
+        super(new BasicSolarPanelContainer(syncId, playerEntity, blockEntity), playerEntity.inventory, new TranslatableComponent("ui.galacticraft-rewoven.basic_solar_panel.name"));
         this.world = playerEntity.world;
     }
 
@@ -73,14 +76,14 @@ public class BasicSolarPanelScreen extends AbstractContainerScreen {
         this.drawMouseoverTooltip(mouseX, mouseY);
     }
 
-    private void drawConfigTabs() {
-        this.minecraft.getTextureManager().bindTexture(CONFIG_TABS);
-        this.blit(this.left - CONFIG_TAB_WIDTH, this.top + 3, CONFIG_TAB_X, CONFIG_TAB_Y, CONFIG_TAB_WIDTH, CONFIG_TAB_HEIGHT);
-    }
+//    public void drawConfigTabs() {
+//        this.minecraft.getTextureManager().bindTexture(CONFIG_TABS);
+//        this.blit(this.left - CONFIG_TAB_WIDTH, this.top + 3, CONFIG_TAB_X, CONFIG_TAB_Y, CONFIG_TAB_WIDTH, CONFIG_TAB_HEIGHT);
+//    }
 
     private void drawEnergyBufferBar() {
-        float currentEnergy = (float) ((BasicSolarPanelBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getCurrentEnergy();
-        float maxEnergy = (float) ((BasicSolarPanelBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getMaxEnergy();
+        float currentEnergy = container.energy.get();
+        float maxEnergy = container.getMaxEnergy();
         float energyScale = (currentEnergy / maxEnergy);
 
         //this.drawTexturedReact(...)
@@ -94,16 +97,16 @@ public class BasicSolarPanelScreen extends AbstractContainerScreen {
         super.drawMouseoverTooltip(mouseX, mouseY);
         if (mouseX >= energyDisplayX && mouseX <= energyDisplayX + ENERGY_WIDTH && mouseY >= energyDisplayY && mouseY <= energyDisplayY + ENERGY_HEIGHT) {
             List<String> toolTipLines = new ArrayList<>();
-            toolTipLines.add(new TranslatableComponent("ui.galacticraft-rewoven.machine.status", ((BasicSolarPanelBlockEntity) world.getBlockEntity(blockPos)).status.toString()).setStyle(new Style().setColor(ChatFormat.GRAY)).getFormattedText());
-            if (((BasicSolarPanelBlockEntity) world.getBlockEntity(blockPos)).status == BasicSolarPanelStatus.COLLECTING) {
+            toolTipLines.add(new TranslatableComponent("ui.galacticraft-rewoven.machine.status", container.blockEntity.status.toString()).setStyle(new Style().setColor(ChatFormat.GRAY)).getFormattedText());
+            if (container.blockEntity.status == BasicSolarPanelStatus.COLLECTING) {
                 if (world.getTimeOfDay() > 6000) {
                     toolTipLines.add(new TranslatableComponent("ui.galacticraft-rewoven.machine.gj_per_t", (int) ((6000D - ((double) world.getTimeOfDay() - 6000D)) / 133.3333333333D)).setStyle(new Style().setColor(ChatFormat.LIGHT_PURPLE)).getFormattedText());
                 } else {
                     toolTipLines.add(new TranslatableComponent("ui.galacticraft-rewoven.machine.gj_per_t", (int) (((double) world.getTimeOfDay()) / 133.3333333333D)).setStyle(new Style().setColor(ChatFormat.LIGHT_PURPLE)).getFormattedText());
                 }
             }
-            toolTipLines.add("\u00A76" + new TranslatableComponent("ui.galacticraft-rewoven.machine.current_energy", new GalacticraftEnergyType().getDisplayAmount(((BasicSolarPanelBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getCurrentEnergy()).setStyle(new Style().setColor(ChatFormat.BLUE))).getFormattedText() + "\u00A7r");
-            toolTipLines.add("\u00A7c" + new TranslatableComponent("ui.galacticraft-rewoven.machine.max_energy", new GalacticraftEnergyType().getDisplayAmount(((BasicSolarPanelBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getMaxEnergy())).getFormattedText() + "\u00A7r");
+            toolTipLines.add("\u00A76" + new TranslatableComponent("ui.galacticraft-rewoven.machine.current_energy", new GalacticraftEnergyType().getDisplayAmount(container.energy.get()).setStyle(new Style().setColor(ChatFormat.BLUE))).getFormattedText() + "\u00A7r");
+            toolTipLines.add("\u00A7c" + new TranslatableComponent("ui.galacticraft-rewoven.machine.max_energy", new GalacticraftEnergyType().getDisplayAmount(container.getMaxEnergy())).getFormattedText() + "\u00A7r");
 
             this.renderTooltip(toolTipLines, mouseX, mouseY);
         }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelStatus.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/basicsolarpanel/BasicSolarPanelStatus.java
@@ -39,4 +39,9 @@ public enum BasicSolarPanelStatus {
     public String toString() {
         return name;
     }
+
+    public static BasicSolarPanelStatus get(int index) {
+        if (index < 0) index=0;
+        return values()[index % values().length];
+    }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/circuitfabricator/CircuitFabricatorBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/circuitfabricator/CircuitFabricatorBlock.java
@@ -87,7 +87,7 @@ public class CircuitFabricatorBlock extends BlockWithEntity implements Attribute
         if (!(be instanceof CircuitFabricatorBlockEntity)) return;
         CircuitFabricatorBlockEntity fabricator = (CircuitFabricatorBlockEntity) be;
         to.offer(fabricator.getEnergy());
-        fabricator.getInventory().offerSelfAsAttribute(to, null, null);
+        fabricator.getExposedInventory().offerSelfAsAttribute(to, null, null);
     }
 
     @Override

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/circuitfabricator/CircuitFabricatorStatus.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/circuitfabricator/CircuitFabricatorStatus.java
@@ -32,4 +32,12 @@ public enum CircuitFabricatorStatus {
     public String toString() {
         return name;
     }
+
+    public static CircuitFabricatorStatus get(int index) {
+        switch (index) {
+            case 0: return PROCESSING;
+            case 1: return IDLE;
+            default: return INACTIVE;
+        }
+    }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/coalgenerator/CoalGeneratorBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/coalgenerator/CoalGeneratorBlock.java
@@ -85,7 +85,7 @@ public class CoalGeneratorBlock extends BlockWithEntity implements AttributeProv
         if (!(be instanceof CoalGeneratorBlockEntity)) return;
         CoalGeneratorBlockEntity generator = (CoalGeneratorBlockEntity) be;
         to.offer(generator.getEnergy());
-        generator.getInventory().offerSelfAsAttribute(to, null, null);
+        generator.getExposedInventory().offerSelfAsAttribute(to, null, null);
     }
 
     @Override

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/coalgenerator/CoalGeneratorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/coalgenerator/CoalGeneratorBlockEntity.java
@@ -1,8 +1,10 @@
 package com.hrznstudio.galacticraft.blocks.machines.coalgenerator;
 
-import alexiil.mc.lib.attributes.DefaultedAttribute;
-import alexiil.mc.lib.attributes.SearchOptions;
 import alexiil.mc.lib.attributes.Simulation;
+import alexiil.mc.lib.attributes.item.filter.AggregateItemFilter;
+import alexiil.mc.lib.attributes.item.filter.ExactItemFilter;
+import alexiil.mc.lib.attributes.item.filter.ItemFilter;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.hrznstudio.galacticraft.api.configurable.SideOptions;
@@ -26,6 +28,14 @@ import java.util.Map;
  * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
  */
 public class CoalGeneratorBlockEntity extends MachineBlockEntity implements Tickable {
+
+    private static final ItemFilter[] SLOT_FILTERS = new ItemFilter[2];
+
+    static {
+        SLOT_FILTERS[0] = AggregateItemFilter.anyOf(createFuelTimeMap().keySet().stream().map(ExactItemFilter::new).toArray(ItemFilter[]::new));
+        SLOT_FILTERS[1] = GalacticraftEnergy.ENERGY_HOLDER_ITEM_FILTER;
+    }
+
     private final List<Runnable> listeners = Lists.newArrayList();
     public CoalGeneratorStatus status = CoalGeneratorStatus.INACTIVE;
     public int fuelTimeMax;
@@ -39,6 +49,7 @@ public class CoalGeneratorBlockEntity extends MachineBlockEntity implements Tick
         super(GalacticraftBlockEntities.COAL_GENERATOR_TYPE);
         //automatically mark dirty whenever the energy attribute is changed
         selectedOptions.put(Direction.SOUTH, SideOptions.POWER_OUTPUT);
+        getLimitedInventory().getRule(0).disallowExtraction();
     }
 
     public static Map<Item, Integer> createFuelTimeMap() {
@@ -59,7 +70,15 @@ public class CoalGeneratorBlockEntity extends MachineBlockEntity implements Tick
     }
 
     @Override
+    protected ItemFilter getFilterForSlot(int slot) {
+        return SLOT_FILTERS[slot];
+    }
+
+    @Override
     public void tick() {
+        if (world.isClient) {
+            return;
+        }
         int prev = getEnergy().getCurrentEnergy();
 
         if (canUseAsFuel(getInventory().getInvStack(0)) && (status == CoalGeneratorStatus.INACTIVE || status == CoalGeneratorStatus.IDLE) && getEnergy().getCurrentEnergy() < getEnergy().getMaxEnergy()) {
@@ -72,7 +91,7 @@ public class CoalGeneratorBlockEntity extends MachineBlockEntity implements Tick
             this.fuelTimeCurrent = 0;
             this.fuelEnergyPerTick = createFuelTimeMap().get(this.getInventory().getInvStack(0).getItem());
 
-            this.getInventory().getInvStack(0).setCount(this.getInventory().getInvStack(0).getCount() - 1);
+            getInventory().getSlot(0).extract(1);
         }
 
         if (this.status == CoalGeneratorStatus.WARMING) {
@@ -94,25 +113,12 @@ public class CoalGeneratorBlockEntity extends MachineBlockEntity implements Tick
 
         for (Direction direction : Direction.values()) {
             if (selectedOptions.get(direction).equals(SideOptions.POWER_OUTPUT)) {
-                EnergyAttribute energyAttribute = getNeighborAttribute(EnergyAttribute.ENERGY_ATTRIBUTE, direction);
+                EnergyAttribute energyAttribute = EnergyAttribute.ENERGY_ATTRIBUTE.getFirstFromNeighbour(this, direction);
                 if (energyAttribute.canInsertEnergy()) {
                     getEnergy().setCurrentEnergy(energyAttribute.insertEnergy(new GalacticraftEnergyType(), 1, Simulation.ACTION));
                 }
             }
         }
-
-        if (getInventory().getInvStack(1).getTag() != null && getEnergy().getCurrentEnergy() > 0) {
-            if (GalacticraftEnergy.isEnergyItem(getInventory().getInvStack(1))) {
-                if (getInventory().getInvStack(1).getTag().getInt("Energy") < getInventory().getInvStack(1).getTag().getInt("MaxEnergy")) {
-                    getEnergy().extractEnergy(GalacticraftEnergy.GALACTICRAFT_JOULES, 1, Simulation.ACTION);
-                    getInventory().getInvStack(1).getTag().putInt("Energy", this.getInventory().getInvStack(1).getTag().getInt("Energy") + 1);
-                    getInventory().getInvStack(1).setDamage(this.getInventory().getInvStack(1).getDamage() - 1);
-                }
-            }
-        }
-    }
-
-    public <T> T getNeighborAttribute(DefaultedAttribute<T> attr, Direction dir) {
-        return attr.getFirst(getWorld(), getPos().offset(dir), SearchOptions.inDirection(dir));
+        attemptDrainPowerToStack(1);
     }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/coalgenerator/CoalGeneratorScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/coalgenerator/CoalGeneratorScreen.java
@@ -5,14 +5,15 @@ import com.hrznstudio.galacticraft.api.screen.MachineContainerScreen;
 import com.hrznstudio.galacticraft.energy.GalacticraftEnergyType;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.hrznstudio.galacticraft.util.DrawableUtils;
+
+import net.fabricmc.fabric.api.container.ContainerFactory;
+
 import net.minecraft.ChatFormat;
+import net.minecraft.client.gui.screen.ingame.AbstractContainerScreen;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.chat.Style;
-import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.BlockPos;
-import net.minecraft.world.World;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +21,9 @@ import java.util.List;
 /**
  * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
  */
-public class CoalGeneratorScreen extends MachineContainerScreen {
+public class CoalGeneratorScreen extends MachineContainerScreen<CoalGeneratorContainer> {
+
+    public static final ContainerFactory<AbstractContainerScreen> FACTORY = createFactory(CoalGeneratorBlockEntity.class, CoalGeneratorScreen::new);
 
     private static final Identifier OVERLAY = new Identifier(Constants.MOD_ID, Constants.ScreenTextures.getRaw(Constants.ScreenTextures.OVERLAY));
     private static final Identifier BACKGROUND = new Identifier(Constants.MOD_ID, Constants.ScreenTextures.getRaw(Constants.ScreenTextures.COAL_GENERATOR_SCREEN));
@@ -34,15 +37,11 @@ public class CoalGeneratorScreen extends MachineContainerScreen {
     private static final int ENERGY_DIMMED_Y = Constants.TextureCoordinates.ENERGY_DARK_Y;
     private static final int ENERGY_DIMMED_WIDTH = Constants.TextureCoordinates.OVERLAY_WIDTH;
     private static final int ENERGY_DIMMED_HEIGHT = Constants.TextureCoordinates.OVERLAY_HEIGHT;
-    BlockPos blockPos;
     private int energyDisplayX = 0;
     private int energyDisplayY = 0;
-    private World world;
 
-    public CoalGeneratorScreen(int syncId, BlockPos blockPos, PlayerEntity playerEntity) {
-        super(new CoalGeneratorContainer(syncId, blockPos, playerEntity), playerEntity.inventory, new TextComponent(new TranslatableComponent("ui.galacticraft-rewoven.coal_generator.name").getFormattedText()));
-        this.blockPos = blockPos;
-        this.world = playerEntity.world;
+    public CoalGeneratorScreen(int syncId, PlayerEntity player, CoalGeneratorBlockEntity blockEntity) {
+        super(new CoalGeneratorContainer(syncId, player, blockEntity), player.inventory, new TranslatableComponent("ui.galacticraft-rewoven.coal_generator.name"));
         this.containerHeight = 176;
     }
 
@@ -72,8 +71,8 @@ public class CoalGeneratorScreen extends MachineContainerScreen {
     }
 
     private void drawEnergyBufferBar() {
-        float currentEnergy = (float) ((CoalGeneratorBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getCurrentEnergy();
-        float maxEnergy = (float) ((CoalGeneratorBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getMaxEnergy();
+        float currentEnergy = container.energy.get();
+        float maxEnergy = container.getMaxEnergy();
         float energyScale = (currentEnergy / maxEnergy);
 
         //this.drawTexturedReact(...)
@@ -87,9 +86,9 @@ public class CoalGeneratorScreen extends MachineContainerScreen {
         super.drawMouseoverTooltip(mouseX, mouseY);
         if (mouseX >= energyDisplayX && mouseX <= energyDisplayX + ENERGY_WIDTH && mouseY >= energyDisplayY && mouseY <= energyDisplayY + ENERGY_HEIGHT) {
             List<String> toolTipLines = new ArrayList<>();
-            toolTipLines.add(new TranslatableComponent("ui.galacticraft-rewoven.machine.status", ((CoalGeneratorBlockEntity) world.getBlockEntity(blockPos)).status.toString()).setStyle(new Style().setColor(ChatFormat.GRAY)).getFormattedText());
-            toolTipLines.add("\u00A76" + new TranslatableComponent("ui.galacticraft-rewoven.machine.current_energy", new GalacticraftEnergyType().getDisplayAmount(((CoalGeneratorBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getCurrentEnergy()).setStyle(new Style().setColor(ChatFormat.BLUE))).getFormattedText() + "\u00A7r");
-            toolTipLines.add("\u00A7c" + new TranslatableComponent("ui.galacticraft-rewoven.machine.max_energy", new GalacticraftEnergyType().getDisplayAmount(((CoalGeneratorBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getMaxEnergy())).getFormattedText() + "\u00A7r");
+            toolTipLines.add(new TranslatableComponent("ui.galacticraft-rewoven.machine.status", container.blockEntity.status.toString()).setStyle(new Style().setColor(ChatFormat.GRAY)).getFormattedText());
+            toolTipLines.add("\u00A76" + new TranslatableComponent("ui.galacticraft-rewoven.machine.current_energy", new GalacticraftEnergyType().getDisplayAmount(container.energy.get()).setStyle(new Style().setColor(ChatFormat.BLUE))).getFormattedText() + "\u00A7r");
+            toolTipLines.add("\u00A7c" + new TranslatableComponent("ui.galacticraft-rewoven.machine.max_energy", new GalacticraftEnergyType().getDisplayAmount(container.getMaxEnergy())).getFormattedText() + "\u00A7r");
 
             this.renderTooltip(toolTipLines, mouseX, mouseY);
         }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/coalgenerator/CoalGeneratorStatus.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/coalgenerator/CoalGeneratorStatus.java
@@ -35,4 +35,9 @@ public enum CoalGeneratorStatus {
     public String toString() {
         return name;
     }
+
+    public static CoalGeneratorStatus get(int index) {
+        if (index < 0) return ACTIVE;
+        return values()[index % values().length];
+    }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/compressor/CompressorBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/compressor/CompressorBlock.java
@@ -86,11 +86,11 @@ public class CompressorBlock extends AbstractHorizontalDirectionalBlock implemen
             if (blockEntity instanceof CompressorBlockEntity) {
                 CompressorBlockEntity be = (CompressorBlockEntity) blockEntity;
 
-                for (int i = 0; i < be.inventory.getSlotCount(); i++) {
-                    ItemStack itemStack = be.inventory.getInvStack(i);
+                for (int i = 0; i < be.getInventory().getSlotCount(); i++) {
+                    ItemStack itemStack = be.getInventory().getInvStack(i);
 
-                    if (itemStack != null) {
-                        world.spawnEntity(new ItemEntity(world, blockPos.getX(), blockPos.getY() + 1, blockPos.getZ(), itemStack));
+                    if (!itemStack.isEmpty()) {
+                        world.spawnEntity(new ItemEntity(world, blockPos.getX(), blockPos.getY() + 1, blockPos.getZ(), itemStack.copy()));
                     }
                 }
             }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/compressor/CompressorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/compressor/CompressorBlockEntity.java
@@ -4,14 +4,19 @@ import alexiil.mc.lib.attributes.DefaultedAttribute;
 import alexiil.mc.lib.attributes.SearchOptions;
 import alexiil.mc.lib.attributes.Simulation;
 import alexiil.mc.lib.attributes.item.compat.InventoryFixedWrapper;
+import alexiil.mc.lib.attributes.item.filter.AggregateItemFilter;
+import alexiil.mc.lib.attributes.item.filter.ExactItemFilter;
+import alexiil.mc.lib.attributes.item.filter.ItemFilter;
 
 import com.hrznstudio.galacticraft.blocks.machines.MachineBlockEntity;
+import com.hrznstudio.galacticraft.blocks.machines.coalgenerator.CoalGeneratorBlockEntity;
 import com.hrznstudio.galacticraft.entity.GalacticraftBlockEntities;
 import com.hrznstudio.galacticraft.recipes.GalacticraftRecipes;
 import com.hrznstudio.galacticraft.recipes.ShapedCompressingRecipe;
 import com.hrznstudio.galacticraft.recipes.ShapelessCompressingRecipe;
 import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.block.entity.FurnaceBlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
@@ -33,7 +38,7 @@ public class CompressorBlockEntity extends MachineBlockEntity implements Tickabl
     public CompressorStatus status = CompressorStatus.INACTIVE;
     public int fuelTime;
     public int maxFuelTime;
-    private int progress;
+    int progress;
 
     public CompressorBlockEntity() {
         this(GalacticraftBlockEntities.COMPRESSOR_TYPE);
@@ -46,6 +51,15 @@ public class CompressorBlockEntity extends MachineBlockEntity implements Tickabl
     @Override
     protected int getInvSize() {
         return 11;
+    }
+
+    @Override
+    protected ItemFilter getFilterForSlot(int slot) {
+        if (slot == FUEL_INPUT_SLOT) {
+            return AbstractFurnaceBlockEntity::canUseAsFuel;
+        } else {
+            return super.getFilterForSlot(slot);
+        }
     }
 
     @Override

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/compressor/CompressorContainer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/compressor/CompressorContainer.java
@@ -1,12 +1,18 @@
 package com.hrznstudio.galacticraft.blocks.machines.compressor;
 
 import alexiil.mc.lib.attributes.item.compat.InventoryFixedWrapper;
+
+import com.hrznstudio.galacticraft.blocks.machines.MachineContainer;
 import com.hrznstudio.galacticraft.blocks.machines.electriccompressor.ElectricCompressorBlockEntity;
 import com.hrznstudio.galacticraft.container.slot.ItemSpecificSlot;
+
+import net.fabricmc.fabric.api.container.ContainerFactory;
+
 import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.container.Container;
 import net.minecraft.container.FurnaceOutputSlot;
+import net.minecraft.container.Property;
 import net.minecraft.container.Slot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
@@ -17,32 +23,29 @@ import net.minecraft.util.math.BlockPos;
 /**
  * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
  */
-public class CompressorContainer extends Container {
+public class CompressorContainer extends MachineContainer<CompressorBlockEntity> {
+
+    public static final ContainerFactory<Container> FACTORY = createFactory(CompressorBlockEntity.class, CompressorContainer::new);
+
     protected Inventory inventory;
     protected int outputSlotId = 0;
     private ItemStack itemStack;
-    private BlockPos blockPos;
-    private CompressorBlockEntity compressor;
-    private PlayerEntity playerEntity;
 
-    public CompressorContainer(int syncId, BlockPos blockPos, PlayerEntity playerEntity) {
-        super(null, syncId);
-        this.blockPos = blockPos;
-        this.playerEntity = playerEntity;
+    public final Property status = Property.create();
+    public final Property progress = Property.create();
+    public final Property fuelTime = Property.create();
 
-        BlockEntity blockEntity = playerEntity.world.getBlockEntity(blockPos);
-
-        if (!(blockEntity instanceof CompressorBlockEntity)) {
-            // TODO: Move this logic somewhere else to just not open this at all.
-            throw new IllegalStateException("Found " + blockEntity + " instead of a compressor!");
-        }
-        this.compressor = (CompressorBlockEntity) blockEntity;
-        this.inventory = new InventoryFixedWrapper(compressor.getInventory()) {
+    public CompressorContainer(int syncId, PlayerEntity playerEntity, CompressorBlockEntity blockEntity) {
+        super(syncId, playerEntity, blockEntity);
+        this.inventory = new InventoryFixedWrapper(blockEntity.getInventory()) {
             @Override
             public boolean canPlayerUseInv(PlayerEntity player) {
                 return CompressorContainer.this.canUse(player);
             }
         };
+        addProperty(status);
+        addProperty(progress);
+        addProperty(fuelTime);
 
         // 3x3 comprerssor input grid
         int slot = 0;
@@ -98,7 +101,7 @@ public class CompressorContainer extends Container {
                 return itemStack;
             }
 
-            if (slotId < this.compressor.getInventory().getSlotCount()) {
+            if (slotId < this.blockEntity.getInventory().getSlotCount()) {
 
                 if (!this.insertItem(itemStack1, this.inventory.getInvSize(), this.slotList.size(), true)) {
                     return ItemStack.EMPTY;
@@ -120,4 +123,19 @@ public class CompressorContainer extends Container {
         return true;
     }
 
+    @Override
+    public void sendContentUpdates() {
+        status.set(blockEntity.status.ordinal());
+        progress.set(blockEntity.getProgress());
+        fuelTime.set(blockEntity.fuelTime);
+        super.sendContentUpdates();
+    }
+    
+    @Override
+    public void setProperties(int index, int value) {
+        super.setProperties(index, value);
+        blockEntity.status = CompressorStatus.get(status.get());
+        blockEntity.progress = progress.get();
+        blockEntity.fuelTime = fuelTime.get();
+    }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/compressor/CompressorContainer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/compressor/CompressorContainer.java
@@ -1,6 +1,6 @@
 package com.hrznstudio.galacticraft.blocks.machines.compressor;
 
-import alexiil.mc.lib.attributes.item.impl.PartialInventoryFixedWrapper;
+import alexiil.mc.lib.attributes.item.compat.InventoryFixedWrapper;
 import com.hrznstudio.galacticraft.blocks.machines.electriccompressor.ElectricCompressorBlockEntity;
 import com.hrznstudio.galacticraft.container.slot.ItemSpecificSlot;
 import net.minecraft.block.entity.AbstractFurnaceBlockEntity;
@@ -37,12 +37,7 @@ public class CompressorContainer extends Container {
             throw new IllegalStateException("Found " + blockEntity + " instead of a compressor!");
         }
         this.compressor = (CompressorBlockEntity) blockEntity;
-        this.inventory = new PartialInventoryFixedWrapper(compressor.inventory) {
-            @Override
-            public void markDirty() {
-                compressor.markDirty();
-            }
-
+        this.inventory = new InventoryFixedWrapper(compressor.getInventory()) {
             @Override
             public boolean canPlayerUseInv(PlayerEntity player) {
                 return CompressorContainer.this.canUse(player);
@@ -103,7 +98,7 @@ public class CompressorContainer extends Container {
                 return itemStack;
             }
 
-            if (slotId < this.compressor.inventory.getSlotCount()) {
+            if (slotId < this.compressor.getInventory().getSlotCount()) {
 
                 if (!this.insertItem(itemStack1, this.inventory.getInvSize(), this.slotList.size(), true)) {
                     return ItemStack.EMPTY;

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/compressor/CompressorStatus.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/compressor/CompressorStatus.java
@@ -30,4 +30,11 @@ public enum CompressorStatus {
         return name;
     }
 
+    public static CompressorStatus get(int index) {
+        switch (index) {
+            case 0: return PROCESSING;
+            case 1: return IDLE;
+            default: return INACTIVE;
+        }
+    }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/electriccompressor/ElectricCompressorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/electriccompressor/ElectricCompressorBlockEntity.java
@@ -1,13 +1,13 @@
 package com.hrznstudio.galacticraft.blocks.machines.electriccompressor;
 
 import alexiil.mc.lib.attributes.Simulation;
-import com.hrznstudio.galacticraft.api.item.EnergyHolderItem;
+import alexiil.mc.lib.attributes.item.filter.ItemFilter;
+
 import com.hrznstudio.galacticraft.blocks.machines.MachineBlockEntity;
 import com.hrznstudio.galacticraft.blocks.machines.compressor.CompressorBlockEntity;
 import com.hrznstudio.galacticraft.blocks.machines.compressor.CompressorStatus;
 import com.hrznstudio.galacticraft.energy.GalacticraftEnergy;
 import com.hrznstudio.galacticraft.entity.GalacticraftBlockEntities;
-import io.github.cottonmc.energy.impl.SimpleEnergyAttribute;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 
@@ -21,6 +21,15 @@ public class ElectricCompressorBlockEntity extends CompressorBlockEntity {
     @Override
     protected int getInvSize() {
         return super.getInvSize() + 1;
+    }
+
+    @Override
+    protected ItemFilter getFilterForSlot(int slot) {
+        if (slot == FUEL_INPUT_SLOT) {
+            return GalacticraftEnergy.ENERGY_HOLDER_ITEM_FILTER;
+        } else {
+            return super.getFilterForSlot(slot);
+        }
     }
 
     @Override
@@ -63,7 +72,7 @@ public class ElectricCompressorBlockEntity extends CompressorBlockEntity {
             }
         }
         if (canCraftTwo) {
-            if (getInventory().getInvStack(OUTPUT_SLOT).getCount() > craftingResult.getMaxCount() || getInventory().getInvStack(SECOND_OUTPUT_SLOT).getCount() > craftingResult.getMaxCount()) {
+            if (getInventory().getInvStack(OUTPUT_SLOT).getCount() >= craftingResult.getMaxCount() || getInventory().getInvStack(SECOND_OUTPUT_SLOT).getCount() >= craftingResult.getMaxCount()) {
                 // There would be too many items in the output slot. Just craft one.
                 canCraftTwo = false;
             }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/electriccompressor/ElectricCompressorContainer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/electriccompressor/ElectricCompressorContainer.java
@@ -3,14 +3,23 @@ package com.hrznstudio.galacticraft.blocks.machines.electriccompressor;
 import com.hrznstudio.galacticraft.blocks.machines.compressor.CompressorBlockEntity;
 import com.hrznstudio.galacticraft.blocks.machines.compressor.CompressorContainer;
 import com.hrznstudio.galacticraft.container.slot.ChargeSlot;
+
+import net.fabricmc.fabric.api.container.ContainerFactory;
+
+import net.minecraft.container.Container;
 import net.minecraft.container.FurnaceOutputSlot;
+import net.minecraft.container.Property;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.math.BlockPos;
 
 public class ElectricCompressorContainer extends CompressorContainer {
-    public ElectricCompressorContainer(int syncId, BlockPos blockPos, PlayerEntity player) {
-        super(syncId, blockPos, player);
 
+    public static final ContainerFactory<Container> ELECTRIC_FACTORY = createFactory(ElectricCompressorBlockEntity.class, ElectricCompressorContainer::new);
+
+    public ElectricCompressorContainer(int syncId, PlayerEntity player, ElectricCompressorBlockEntity blockEntity) {
+        super(syncId, player, blockEntity);
+
+        addProperty(energy);
         addSlot(new FurnaceOutputSlot(player, this.inventory, ElectricCompressorBlockEntity.SECOND_OUTPUT_SLOT, getOutputSlotPos()[0], getOutputSlotPos()[1] + 18));
         addSlot(new ChargeSlot(this.inventory, CompressorBlockEntity.FUEL_INPUT_SLOT, 3 * 18 + 1, 75));
     }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/electriccompressor/ElectricCompressorScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/electriccompressor/ElectricCompressorScreen.java
@@ -2,14 +2,19 @@ package com.hrznstudio.galacticraft.blocks.machines.electriccompressor;
 
 import com.hrznstudio.galacticraft.Constants;
 import com.hrznstudio.galacticraft.blocks.machines.compressor.CompressorScreen;
+
+import net.fabricmc.fabric.api.container.ContainerFactory;
+
+import net.minecraft.client.gui.screen.ingame.AbstractContainerScreen;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.network.chat.TranslatableComponent;
-import net.minecraft.util.math.BlockPos;
 
 public class ElectricCompressorScreen extends CompressorScreen {
-    public ElectricCompressorScreen(int syncId, BlockPos blockPos, PlayerEntity playerEntity) {
-        super(new ElectricCompressorContainer(syncId, blockPos, playerEntity), blockPos, playerEntity, new TranslatableComponent("ui.galacticraft-rewoven.electric_compressor.name"));
-//        BlockPos blockPos, PlayerEntity playerEntity, TranslatableComponent textComponents
+
+    public static final ContainerFactory<AbstractContainerScreen> ELECTRIC_FACTORY = createFactory(ElectricCompressorBlockEntity.class, ElectricCompressorScreen::new);
+
+    public ElectricCompressorScreen(int syncId, PlayerEntity playerEntity, ElectricCompressorBlockEntity blockEntity) {
+        super(new ElectricCompressorContainer(syncId, playerEntity, blockEntity), playerEntity, new TranslatableComponent("ui.galacticraft-rewoven.electric_compressor.name"));
         this.containerHeight = 199;
     }
 

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/energystoragemodule/EnergyStorageModuleBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/energystoragemodule/EnergyStorageModuleBlockEntity.java
@@ -1,12 +1,11 @@
 package com.hrznstudio.galacticraft.blocks.machines.energystoragemodule;
 
-import alexiil.mc.lib.attributes.item.impl.SimpleFixedItemInv;
 import com.hrznstudio.galacticraft.blocks.machines.MachineBlockEntity;
 import com.hrznstudio.galacticraft.energy.GalacticraftEnergy;
 import com.hrznstudio.galacticraft.entity.GalacticraftBlockEntities;
-import io.github.cottonmc.energy.impl.SimpleEnergyAttribute;
-import net.minecraft.item.ItemStack;
 import net.minecraft.util.Tickable;
+
+import alexiil.mc.lib.attributes.item.filter.ItemFilter;
 
 /**
  * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
@@ -15,9 +14,6 @@ public class EnergyStorageModuleBlockEntity extends MachineBlockEntity implement
     public static int MAX_ENERGY = 60000;
     public static int CHARGE_BATTERY_SLOT = 0;
     public static int DRAIN_BATTERY_SLOT = 1;
-    SimpleFixedItemInv inventory = new SimpleFixedItemInv(2);
-    private SimpleEnergyAttribute energy = new SimpleEnergyAttribute(MAX_ENERGY, GalacticraftEnergy.GALACTICRAFT_JOULES);
-    private int powerToChargePerTick = 5;
 
     public EnergyStorageModuleBlockEntity() {
         super(GalacticraftBlockEntities.ENERGY_STORAGE_MODULE_TYPE);
@@ -34,32 +30,21 @@ public class EnergyStorageModuleBlockEntity extends MachineBlockEntity implement
     }
 
     @Override
+    protected ItemFilter getFilterForSlot(int slot) {
+        return GalacticraftEnergy.ENERGY_HOLDER_ITEM_FILTER;
+    }
+
+    @Override
+    protected int getBatteryTransferRate() {
+        return 5;
+    }
+
+    @Override
     public void tick() {
-        // Charge the battery, drain internal energy buffer.
-        ItemStack batteryToCharge = getInventory().getInvStack(CHARGE_BATTERY_SLOT);
-        if (GalacticraftEnergy.isEnergyItem(batteryToCharge) && this.getEnergy().getCurrentEnergy() > 0) {
-            int currentBatteryCharge = GalacticraftEnergy.getBatteryEnergy(batteryToCharge);
-            int maxBatteryCharge = GalacticraftEnergy.getMaxBatteryEnergy(batteryToCharge);
-            int chargeRoom = maxBatteryCharge - currentBatteryCharge;
-
-            int chargeToAdd = Math.min(powerToChargePerTick, chargeRoom);
-            chargeToAdd = Math.min(chargeToAdd, this.getEnergy().getCurrentEnergy());
-
-            this.getEnergy().setCurrentEnergy(getEnergy().getCurrentEnergy() - chargeToAdd);
-
-            GalacticraftEnergy.incrementEnergy(batteryToCharge, chargeToAdd);
+        if (world.isClient) {
+            return;
         }
-
-        // Drain the battery, charge internal energy buffer.
-        ItemStack batteryToDrain = getInventory().getInvStack(DRAIN_BATTERY_SLOT);
-        if (GalacticraftEnergy.isEnergyItem(batteryToDrain) && this.getEnergy().getCurrentEnergy() < this.getEnergy().getMaxEnergy()) {
-            int currentBatteryCharge = GalacticraftEnergy.getBatteryEnergy(batteryToDrain);
-
-            int chargeToRemove = Math.min(powerToChargePerTick, currentBatteryCharge);
-            int newInternalBuffer = getEnergy().getCurrentEnergy() + chargeToRemove;
-
-            this.getEnergy().setCurrentEnergy(newInternalBuffer);
-            GalacticraftEnergy.decrementEnergy(batteryToDrain, chargeToRemove);
-        }
+        attemptChargeFromStack(DRAIN_BATTERY_SLOT);
+        attemptDrainPowerToStack(CHARGE_BATTERY_SLOT);
     }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/energystoragemodule/EnergyStorageModuleContainer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/energystoragemodule/EnergyStorageModuleContainer.java
@@ -1,44 +1,30 @@
 package com.hrznstudio.galacticraft.blocks.machines.energystoragemodule;
 
-import alexiil.mc.lib.attributes.item.impl.PartialInventoryFixedWrapper;
+import alexiil.mc.lib.attributes.item.compat.InventoryFixedWrapper;
+
+import com.hrznstudio.galacticraft.blocks.machines.MachineContainer;
 import com.hrznstudio.galacticraft.container.slot.ChargeSlot;
-import net.minecraft.block.entity.BlockEntity;
+
+import net.fabricmc.fabric.api.container.ContainerFactory;
+
 import net.minecraft.container.Container;
 import net.minecraft.container.Slot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.BlockPos;
 
 /**
  * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
  */
-public class EnergyStorageModuleContainer extends Container {
+public class EnergyStorageModuleContainer extends MachineContainer<EnergyStorageModuleBlockEntity> {
+    public static final ContainerFactory<Container> FACTORY = createFactory(EnergyStorageModuleBlockEntity.class, EnergyStorageModuleContainer::new);
+
     private ItemStack itemStack;
     private Inventory inventory;
 
-    private BlockPos blockPos;
-    private EnergyStorageModuleBlockEntity module;
-    private PlayerEntity playerEntity;
-
-    public EnergyStorageModuleContainer(int syncId, BlockPos blockPos, PlayerEntity playerEntity) {
-        super(null, syncId);
-        this.blockPos = blockPos;
-        this.playerEntity = playerEntity;
-
-        BlockEntity blockEntity = playerEntity.world.getBlockEntity(blockPos);
-
-        if (!(blockEntity instanceof EnergyStorageModuleBlockEntity)) {
-            // TODO: Move this logic somewhere else to just not open this at all.
-            throw new IllegalStateException("Found " + blockEntity + " instead of an EnergyStorageModuleBlockEntity!");
-        }
-        this.module = (EnergyStorageModuleBlockEntity) blockEntity;
-        this.inventory = new PartialInventoryFixedWrapper(module.getInventory()) {
-            @Override
-            public void markDirty() {
-                module.markDirty();
-            }
-
+    public EnergyStorageModuleContainer(int syncId, PlayerEntity playerEntity, EnergyStorageModuleBlockEntity blockEntity) {
+        super(syncId, playerEntity, blockEntity);
+        this.inventory = new InventoryFixedWrapper(blockEntity.getInventory()) {
             @Override
             public boolean canPlayerUseInv(PlayerEntity player) {
                 return EnergyStorageModuleContainer.this.canUse(player);
@@ -77,7 +63,7 @@ public class EnergyStorageModuleContainer extends Container {
                 return itemStack;
             }
 
-            if (slotId < this.module.getInventory().getSlotCount()) {
+            if (slotId < this.blockEntity.getInventory().getSlotCount()) {
 
                 if (!this.insertItem(itemStack1, this.inventory.getInvSize(), this.slotList.size(), true)) {
                     return ItemStack.EMPTY;

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/energystoragemodule/EnergyStorageModuleScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/energystoragemodule/EnergyStorageModuleScreen.java
@@ -1,9 +1,13 @@
 package com.hrznstudio.galacticraft.blocks.machines.energystoragemodule;
 
 import com.hrznstudio.galacticraft.Constants;
+import com.hrznstudio.galacticraft.api.screen.MachineContainerScreen;
 import com.hrznstudio.galacticraft.energy.GalacticraftEnergyType;
 import com.mojang.blaze3d.platform.GlStateManager;
 import com.hrznstudio.galacticraft.util.DrawableUtils;
+
+import net.fabricmc.fabric.api.container.ContainerFactory;
+
 import net.minecraft.ChatFormat;
 import net.minecraft.client.gui.screen.ingame.AbstractContainerScreen;
 import net.minecraft.entity.player.PlayerEntity;
@@ -19,7 +23,9 @@ import java.util.List;
 /**
  * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
  */
-public class EnergyStorageModuleScreen extends AbstractContainerScreen {
+public class EnergyStorageModuleScreen extends MachineContainerScreen<EnergyStorageModuleContainer> {
+    public static final ContainerFactory<AbstractContainerScreen> FACTORY = createFactory(EnergyStorageModuleBlockEntity.class, EnergyStorageModuleScreen::new);
+
     private static final Identifier OVERLAY = new Identifier(Constants.MOD_ID, Constants.ScreenTextures.getRaw(Constants.ScreenTextures.OVERLAY));
     private static final Identifier BACKGROUND = new Identifier(Constants.MOD_ID, Constants.ScreenTextures.getRaw(Constants.ScreenTextures.ENERGY_STORAGE_MODULE_SCREEN));
     private static final Identifier CONFIG_TABS = new Identifier(Constants.MOD_ID, Constants.ScreenTextures.getRaw(Constants.ScreenTextures.MACHINE_CONFIG_TABS));
@@ -39,12 +45,9 @@ public class EnergyStorageModuleScreen extends AbstractContainerScreen {
     BlockPos blockPos;
     private int energyDisplayX = 0;
     private int energyDisplayY = 0;
-    private World world;
 
-    public EnergyStorageModuleScreen(int syncId, BlockPos blockPos, PlayerEntity playerEntity) {
-        super(new EnergyStorageModuleContainer(syncId, blockPos, playerEntity), playerEntity.inventory, new TranslatableComponent("ui.galacticraft-rewoven.energy_storage_module.name"));
-        this.blockPos = blockPos;
-        this.world = playerEntity.world;
+    public EnergyStorageModuleScreen(int syncId, PlayerEntity playerEntity, EnergyStorageModuleBlockEntity blockEntity) {
+        super(new EnergyStorageModuleContainer(syncId, playerEntity, blockEntity), playerEntity.inventory, new TranslatableComponent("ui.galacticraft-rewoven.energy_storage_module.name"));
 //        this.containerHeight = 166;
     }
 
@@ -73,14 +76,14 @@ public class EnergyStorageModuleScreen extends AbstractContainerScreen {
         this.drawMouseoverTooltip(mouseX, mouseY);
     }
 
-    private void drawConfigTabs() {
+    public void drawConfigTabs() {
         this.minecraft.getTextureManager().bindTexture(CONFIG_TABS);
         this.blit(this.left - CONFIG_TAB_WIDTH, this.top + 3, CONFIG_TAB_X, CONFIG_TAB_Y, CONFIG_TAB_WIDTH, CONFIG_TAB_HEIGHT);
     }
 
     private void drawEnergyBufferBar() {
-        float currentEnergy = (float) ((EnergyStorageModuleBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getCurrentEnergy();
-        float maxEnergy = (float) ((EnergyStorageModuleBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getMaxEnergy();
+        float currentEnergy = container.energy.get();
+        float maxEnergy = container.getMaxEnergy();
         float energyScale = (currentEnergy / maxEnergy);
 
         this.minecraft.getTextureManager().bindTexture(OVERLAY);
@@ -93,8 +96,8 @@ public class EnergyStorageModuleScreen extends AbstractContainerScreen {
         super.drawMouseoverTooltip(mouseX, mouseY);
         if (mouseX >= energyDisplayX && mouseX <= energyDisplayX + ENERGY_WIDTH && mouseY >= energyDisplayY && mouseY <= energyDisplayY + ENERGY_HEIGHT) {
             List<String> toolTipLines = new ArrayList<>();
-            toolTipLines.add("\u00A76" + new TranslatableComponent("ui.galacticraft-rewoven.machine.current_energy", new GalacticraftEnergyType().getDisplayAmount(((EnergyStorageModuleBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getCurrentEnergy()).setStyle(new Style().setColor(ChatFormat.BLUE))).getFormattedText() + "\u00A7r");
-            toolTipLines.add("\u00A7c" + new TranslatableComponent("ui.galacticraft-rewoven.machine.max_energy", new GalacticraftEnergyType().getDisplayAmount(((EnergyStorageModuleBlockEntity) world.getBlockEntity(blockPos)).getEnergy().getMaxEnergy())).getFormattedText() + "\u00A7r");
+            toolTipLines.add("\u00A76" + new TranslatableComponent("ui.galacticraft-rewoven.machine.current_energy", new GalacticraftEnergyType().getDisplayAmount(container.energy.get()).setStyle(new Style().setColor(ChatFormat.BLUE))).getFormattedText() + "\u00A7r");
+            toolTipLines.add("\u00A7c" + new TranslatableComponent("ui.galacticraft-rewoven.machine.max_energy", new GalacticraftEnergyType().getDisplayAmount(container.getMaxEnergy())).getFormattedText() + "\u00A7r");
 
             this.renderTooltip(toolTipLines, mouseX, mouseY);
         }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/oxygencollector/CollectorStatus.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/oxygencollector/CollectorStatus.java
@@ -14,4 +14,9 @@ public enum CollectorStatus {
     public int getTextColor() {
         return textColor;
     }
+
+    public static CollectorStatus get(int index) {
+        if (index < 0) return values()[0];
+        return values()[index % values().length];
+    }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/oxygencollector/OxygenCollectorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/oxygencollector/OxygenCollectorBlockEntity.java
@@ -1,6 +1,8 @@
 package com.hrznstudio.galacticraft.blocks.machines.oxygencollector;
 
 import alexiil.mc.lib.attributes.Simulation;
+import alexiil.mc.lib.attributes.item.filter.ItemFilter;
+
 import com.hrznstudio.galacticraft.api.world.dimension.SpaceDimension;
 import com.hrznstudio.galacticraft.blocks.machines.MachineBlockEntity;
 import com.hrznstudio.galacticraft.energy.GalacticraftEnergy;
@@ -15,11 +17,13 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Tickable;
 import net.minecraft.util.math.BlockPos;
 
-public class OxygenCollectorBlockEntity extends MachineBlockEntity implements Tickable, BlockEntityClientSerializable {
-    public static int BATTERY_SLOT = 0;
+public class OxygenCollectorBlockEntity extends MachineBlockEntity implements Tickable {
+    public static final int MAX_OXYGEN = 5000;
+    public static final int BATTERY_SLOT = 0;
+
     public CollectorStatus status = CollectorStatus.INACTIVE;
     public int lastCollectAmount = 0;
-    private SimpleEnergyAttribute oxygen = new SimpleEnergyAttribute(5000, GalacticraftEnergy.GALACTICRAFT_OXYGEN);
+    private SimpleEnergyAttribute oxygen = new SimpleEnergyAttribute(MAX_OXYGEN, GalacticraftEnergy.GALACTICRAFT_OXYGEN);
 
     public OxygenCollectorBlockEntity() {
         super(GalacticraftBlockEntities.OXYGEN_COLLECTOR_TYPE);
@@ -28,6 +32,11 @@ public class OxygenCollectorBlockEntity extends MachineBlockEntity implements Ti
     @Override
     protected int getInvSize() {
         return 1;
+    }
+
+    @Override
+    protected ItemFilter getFilterForSlot(int slot) {
+        return GalacticraftEnergy.ENERGY_HOLDER_ITEM_FILTER;
     }
 
     private int collectOxygen(BlockPos center) {
@@ -68,7 +77,10 @@ public class OxygenCollectorBlockEntity extends MachineBlockEntity implements Ti
 
     @Override
     public void tick() {
-        attemptChargeFromStack(getInventory().getInvStack(BATTERY_SLOT));
+        if (world.isClient) {
+            return;
+        }
+        attemptChargeFromStack(BATTERY_SLOT);
 
         // Only collect every 20 ticks
         if (world.random.nextInt(10) != 0) {

--- a/src/main/java/com/hrznstudio/galacticraft/blocks/machines/oxygencollector/OxygenCollectorContainer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/blocks/machines/oxygencollector/OxygenCollectorContainer.java
@@ -7,14 +7,12 @@ import com.hrznstudio.galacticraft.container.slot.ChargeSlot;
 
 import net.fabricmc.fabric.api.container.ContainerFactory;
 
-import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.container.Container;
 import net.minecraft.container.Property;
 import net.minecraft.container.Slot;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.math.BlockPos;
 
 /**
  * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
@@ -25,6 +23,7 @@ public class OxygenCollectorContainer extends MachineContainer<OxygenCollectorBl
     private ItemStack itemStack;
     private Inventory inventory;
 
+    public final Property status = Property.create();
     public final Property oxygen = Property.create();
     public final Property lastCollectAmount = Property.create();
 
@@ -36,6 +35,7 @@ public class OxygenCollectorContainer extends MachineContainer<OxygenCollectorBl
                 return OxygenCollectorContainer.this.canUse(player);
             }
         };
+        addProperty(status);
         addProperty(oxygen);
         addProperty(lastCollectAmount);
 
@@ -93,11 +93,18 @@ public class OxygenCollectorContainer extends MachineContainer<OxygenCollectorBl
     public boolean canUse(PlayerEntity playerEntity) {
         return true;
     }
-    
+
     @Override
     public void sendContentUpdates() {
+        status.set(blockEntity.status.ordinal());
         oxygen.set(blockEntity.getOxygen().getCurrentEnergy());
         lastCollectAmount.set(blockEntity.lastCollectAmount);
         super.sendContentUpdates();
+    }
+    
+    @Override
+    public void setProperties(int index, int value) {
+        super.setProperties(index, value);
+        blockEntity.status = CollectorStatus.get(status.get());
     }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/container/GalacticraftContainers.java
+++ b/src/main/java/com/hrznstudio/galacticraft/container/GalacticraftContainers.java
@@ -29,9 +29,9 @@ public class GalacticraftContainers {
     public static void register() {
         ContainerProviderRegistry.INSTANCE.registerFactory(PLAYER_INVENTORY_CONTAINER, (syncId, id, player, buf) -> new PlayerInventoryGCContainer(player.inventory, !player.world.isClient, player));
 
-        ContainerProviderRegistry.INSTANCE.registerFactory(COAL_GENERATOR_CONTAINER, (syncId, id, player, buf) -> new CoalGeneratorContainer(syncId, buf.readBlockPos(), player));
-        ContainerProviderRegistry.INSTANCE.registerFactory(CIRCUIT_FABRICATOR_CONTAINER, (syncId, id, player, buf) -> new CircuitFabricatorContainer(syncId, buf.readBlockPos(), player));
-        ContainerProviderRegistry.INSTANCE.registerFactory(BASIC_SOLAR_PANEL_CONTAINER, (syncId, id, player, buf) -> new BasicSolarPanelContainer(syncId, buf.readBlockPos(), player));
+        ContainerProviderRegistry.INSTANCE.registerFactory(COAL_GENERATOR_CONTAINER, CoalGeneratorContainer.FACTORY);
+        ContainerProviderRegistry.INSTANCE.registerFactory(CIRCUIT_FABRICATOR_CONTAINER, CircuitFabricatorContainer.FACTORY);
+        ContainerProviderRegistry.INSTANCE.registerFactory(BASIC_SOLAR_PANEL_CONTAINER, BasicSolarPanelContainer.FACTORY);
         ContainerProviderRegistry.INSTANCE.registerFactory(COMPRESSOR_CONTAINER, (syncId, id, player, buf) -> new CompressorContainer(syncId, buf.readBlockPos(), player));
         ContainerProviderRegistry.INSTANCE.registerFactory(ELECTRIC_COMPRESSOR_CONTAINER, (syncId, id, player, buf) -> new ElectricCompressorContainer(syncId, buf.readBlockPos(), player));
         ContainerProviderRegistry.INSTANCE.registerFactory(ENERGY_STORAGE_MODULE_CONTAINER, (syncId, id, player, buf) -> new EnergyStorageModuleContainer(syncId, buf.readBlockPos(), player));

--- a/src/main/java/com/hrznstudio/galacticraft/container/GalacticraftContainers.java
+++ b/src/main/java/com/hrznstudio/galacticraft/container/GalacticraftContainers.java
@@ -32,9 +32,9 @@ public class GalacticraftContainers {
         ContainerProviderRegistry.INSTANCE.registerFactory(COAL_GENERATOR_CONTAINER, CoalGeneratorContainer.FACTORY);
         ContainerProviderRegistry.INSTANCE.registerFactory(CIRCUIT_FABRICATOR_CONTAINER, CircuitFabricatorContainer.FACTORY);
         ContainerProviderRegistry.INSTANCE.registerFactory(BASIC_SOLAR_PANEL_CONTAINER, BasicSolarPanelContainer.FACTORY);
-        ContainerProviderRegistry.INSTANCE.registerFactory(COMPRESSOR_CONTAINER, (syncId, id, player, buf) -> new CompressorContainer(syncId, buf.readBlockPos(), player));
-        ContainerProviderRegistry.INSTANCE.registerFactory(ELECTRIC_COMPRESSOR_CONTAINER, (syncId, id, player, buf) -> new ElectricCompressorContainer(syncId, buf.readBlockPos(), player));
-        ContainerProviderRegistry.INSTANCE.registerFactory(ENERGY_STORAGE_MODULE_CONTAINER, (syncId, id, player, buf) -> new EnergyStorageModuleContainer(syncId, buf.readBlockPos(), player));
-        ContainerProviderRegistry.INSTANCE.registerFactory(OXYGEN_COLLECTOR_CONTAINER, (syncId, id, player, buf) -> new OxygenCollectorContainer(syncId, buf.readBlockPos(), player));
+        ContainerProviderRegistry.INSTANCE.registerFactory(COMPRESSOR_CONTAINER, CompressorContainer.FACTORY);
+        ContainerProviderRegistry.INSTANCE.registerFactory(ELECTRIC_COMPRESSOR_CONTAINER, ElectricCompressorContainer.ELECTRIC_FACTORY);
+        ContainerProviderRegistry.INSTANCE.registerFactory(ENERGY_STORAGE_MODULE_CONTAINER, EnergyStorageModuleContainer.FACTORY);
+        ContainerProviderRegistry.INSTANCE.registerFactory(OXYGEN_COLLECTOR_CONTAINER, OxygenCollectorContainer.FACTORY);
     }
 }

--- a/src/main/java/com/hrznstudio/galacticraft/energy/GalacticraftEnergy.java
+++ b/src/main/java/com/hrznstudio/galacticraft/energy/GalacticraftEnergy.java
@@ -9,6 +9,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
+
+import alexiil.mc.lib.attributes.item.filter.ItemClassFilter;
+import alexiil.mc.lib.attributes.item.filter.ItemFilter;
+
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
@@ -20,6 +24,8 @@ public class GalacticraftEnergy {
 
     public static final EnergyType GALACTICRAFT_JOULES = new GalacticraftEnergyType();
     public static final EnergyType GALACTICRAFT_OXYGEN = new OxygenEnergyType();
+
+    public static final ItemFilter ENERGY_HOLDER_ITEM_FILTER = new ItemClassFilter(EnergyHolderItem.class);
 
     public static void register() {
         Registry.register(CottonEnergy.ENERGY_REGISTRY, new Identifier(Constants.MOD_ID, Constants.Energy.GALACTICRAFT_JOULES), GALACTICRAFT_JOULES);
@@ -43,7 +49,7 @@ public class GalacticraftEnergy {
             throw new IllegalArgumentException("Provided argument is not an energy item!");
         }
 
-        return battery.getTag().getInt("MaxEnergy");
+        return ((EnergyHolderItem) battery.getItem()).getMaxEnergy(battery);
     }
 
     public static void incrementEnergy(ItemStack stack, int energyToAdd) {

--- a/src/main/java/com/hrznstudio/galacticraft/items/BatteryItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/BatteryItem.java
@@ -30,6 +30,11 @@ public class BatteryItem extends Item implements EnergyHolderItem {
     }
 
     @Override
+    public int getMaxEnergy(ItemStack battery) {
+        return MAX_ENERGY;
+    }
+
+    @Override
     @Environment(EnvType.CLIENT)
     public void appendTooltip(ItemStack stack, World world, List<Component> lines, TooltipContext context) {
         int charge = stack.getOrCreateTag().getInt("Energy");

--- a/src/main/java/com/hrznstudio/galacticraft/items/InfiniteBatteryItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/InfiniteBatteryItem.java
@@ -15,6 +15,11 @@ public class InfiniteBatteryItem extends Item implements EnergyHolderItem {
     }
 
     @Override
+    public int getMaxEnergy(ItemStack battery) {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
     public boolean hasEnchantmentGlint(ItemStack itemStack_1) {
         return true;
     }


### PR DESCRIPTION
A few notes:

- The refinery container + screen have errors compiling ATM - they don't seem to be registered in GalacticraftContainers or GalacticraftClient ? (Plus it references the OxygenCollectorContainer instead of the RefineryContainer - is that a typo?
- I've changed the way that containers + screens are created - hopefully that's ok?
- I've made most of the machines sync their status in the container via `Property`'s rather than tick on the client. (Theoretically this should prevent desyncs between multiple clients and the server)