### PR TITLE
Some polishing to my shift-clicking

### DIFF
--- a/src/main/java/com/hrznstudio/galacticraft/screen/PlayerInventoryGCScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/PlayerInventoryGCScreenHandler.java
@@ -177,13 +177,21 @@ public class PlayerInventoryGCScreenHandler extends ScreenHandler {
         if (slotFrom != null && slotFrom.hasStack()) {
             ItemStack stackFrom = slotFrom.getStack();
             stack = stackFrom.copy();
-            if (index >= 0 && index < 8) {
-                if (!this.insertItem(stackFrom, 9, 48, true)) {
+            if (index >= 0 && index < 12) {
+                if (!this.insertItem(stackFrom, 12, 48, false)) {
                     return ItemStack.EMPTY;
                 }
-            } else if (index >= 9 && index < 49) {
+            } else if (index < 39) {
                 if (!this.insertItem(stackFrom, 0, 8, true)) {
-                    return ItemStack.EMPTY;
+                    if (!this.insertItem(stackFrom, 39, 48, false)) {
+                        return ItemStack.EMPTY;
+                    }
+                }
+            } else if (index < 49) {
+                if (!this.insertItem(stackFrom, 0, 8, true)) {
+                    if (!this.insertItem(stackFrom, 12, 39, false)) {
+                        return ItemStack.EMPTY;
+                    }
                 }
             }
 

--- a/src/main/java/com/hrznstudio/galacticraft/screen/PlayerInventoryGCScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/PlayerInventoryGCScreenHandler.java
@@ -177,6 +177,15 @@ public class PlayerInventoryGCScreenHandler extends ScreenHandler {
         if (slotFrom != null && slotFrom.hasStack()) {
             ItemStack stackFrom = slotFrom.getStack();
             stack = stackFrom.copy();
+
+            // Index of Indexes :)
+            // 0-3 (4): GC, armor slots;
+            // 4: GC, mask slot;
+            // 5: GC, oxygen gear;
+            // 6-7 (2): GC, oxygen tanks slots;
+            // 8-11 (4): GC, slots without any required item;
+            // 12-38 (27): MC, non-hotbar inventory slots;
+            // 39-48 (9): MC, hotbar slots.
             if (index >= 0 && index < 12) {
                 if (!this.insertItem(stackFrom, 12, 48, false)) {
                     return ItemStack.EMPTY;


### PR DESCRIPTION
Since now items shift-clicked in hotbar are moved to the main inventory and items shift-clicked in the main inventory are moved to hotbar. Of course it doesn't happen when the target inventory area is full, or when the item is moved to galacticraft slots instead.
Also added some comments to describe the index value.