### PR TITLE
Obtaining compressed steel with two steel ingots

### DIFF
--- a/src/main/resources/data/galacticraft-rewoven/recipes/compressing_compressed_steel_from_ingots.json
+++ b/src/main/resources/data/galacticraft-rewoven/recipes/compressing_compressed_steel_from_ingots.json
@@ -1,0 +1,15 @@
+{
+  "type": "galacticraft-rewoven:compressing_shapeless",
+  "ingredients": [
+    {
+      "item": "c:steel_ingot"
+    },
+    {
+      "item": "c:steel_ingot"
+    }
+  ],
+  "result": {
+    "item": "galacticraft-rewoven:compressed_steel",
+    "count": 1
+  }
+}


### PR DESCRIPTION
![aaaaa](https://user-images.githubusercontent.com/53908689/88943686-13f06f00-d28c-11ea-9606-bb857f44d9ca.png)
Even though steel ingot is not obtainable in Galacticraft: Rewoven nor original Galacticraft, [according to OG wiki](https://wiki.micdoodle8.com/wiki/Steel_Ingot) the original version of the mod allowed steel ingots added by other mods to be used to craft the compressed steel. I think it is a very nice feature, and implemented it in this pull request. It is working with steel ingots from Cotton Resources library.