### PR TITLE
chore: update copyright year to 2021

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 HRZN LTD
+Copyright (c) 2019-2021 HRZN LTD
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/Constants.java
+++ b/src/main/java/com/hrznstudio/galacticraft/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/Galacticraft.java
+++ b/src/main/java/com/hrznstudio/galacticraft/Galacticraft.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/GalacticraftClient.java
+++ b/src/main/java/com/hrznstudio/galacticraft/GalacticraftClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/accessor/GCBiomePropertyAccessor.java
+++ b/src/main/java/com/hrznstudio/galacticraft/accessor/GCBiomePropertyAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/accessor/WorldRendererAccessor.java
+++ b/src/main/java/com/hrznstudio/galacticraft/accessor/WorldRendererAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/biome/BiomeProperty.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/biome/BiomeProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/biome/BiomePropertyType.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/biome/BiomePropertyType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/biome/GalacticraftBiomeProperties.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/biome/GalacticraftBiomeProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/AbstractDirectionalBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/AbstractDirectionalBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/AbstractHorizontalDirectionalBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/AbstractHorizontalDirectionalBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/ConfigurableMachineBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/ConfigurableMachineBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/ConfiguredSideOption.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/ConfiguredSideOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/FluidBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/FluidBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/FluidLoggableBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/FluidLoggableBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/FluidPipe.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/FluidPipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/MultiBlockBase.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/MultiBlockBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/SideOption.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/SideOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/WireBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/WireBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/entity/ConfigurableMachineBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/entity/ConfigurableMachineBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/entity/WireBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/entity/WireBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/package-info.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/block/util/BlockFace.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/block/util/BlockFace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/capes/CapeListener.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/capes/CapeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/capes/models/CapePlayer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/capes/models/CapePlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/capes/models/CapesModel.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/capes/models/CapesModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/config/Config.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/config/Config.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/config/ConfigManager.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/config/ConfigManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/entity/attribute/GalacticraftEntityAttributes.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/entity/attribute/GalacticraftEntityAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/entry/EarthReentryPathfinder.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/entry/EarthReentryPathfinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/item/AccessoryItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/item/AccessoryItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/item/SchematicItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/item/SchematicItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/pipe/Pipe.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/pipe/Pipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/pipe/PipeConnectionType.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/pipe/PipeConnectionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/pipe/PipeNetwork.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/pipe/PipeNetwork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/pipe/impl/PipeNetworkImpl.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/pipe/impl/PipeNetworkImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/screen/MachineHandledScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/screen/MachineHandledScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/wire/Wire.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/wire/Wire.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/wire/WireConnectionType.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/wire/WireConnectionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/wire/WireNetwork.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/wire/WireNetwork.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/api/wire/impl/WireNetworkImpl.java
+++ b/src/main/java/com/hrznstudio/galacticraft/api/wire/impl/WireNetworkImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/GalacticraftBlocks.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/GalacticraftBlocks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/decoration/GratingBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/decoration/GratingBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/decoration/LightPanelBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/decoration/LightPanelBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/decoration/LunarCartographyTableBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/decoration/LunarCartographyTableBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/decoration/VacuumGlassBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/decoration/VacuumGlassBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/AdvancedSolarPanelBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/AdvancedSolarPanelBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/BasicSolarPanelBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/BasicSolarPanelBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/BubbleDistributorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/BubbleDistributorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/CircuitFabricatorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/CircuitFabricatorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/CoalGeneratorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/CoalGeneratorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/CompressorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/CompressorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/ElectricArcFurnaceBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/ElectricArcFurnaceBlockEntity.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.block.entity;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/ElectricCompressorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/ElectricCompressorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/ElectricFurnaceBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/ElectricFurnaceBlockEntity.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.block.entity;
 
 import com.google.common.collect.ImmutableList;

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/EnergyStorageModuleBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/EnergyStorageModuleBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/OxygenCollectorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/OxygenCollectorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/OxygenCompressorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/OxygenCompressorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/OxygenDecompressorBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/OxygenDecompressorBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/OxygenStorageModuleBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/OxygenStorageModuleBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/RefineryBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/RefineryBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/entity/SolarPanelPartBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/entity/SolarPanelPartBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/CavernousVineBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/CavernousVineBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/CavernousVineBlockPoisonous.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/CavernousVineBlockPoisonous.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/CrudeOilBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/CrudeOilBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/GlowstoneLanternBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/GlowstoneLanternBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/GlowstoneTorchBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/GlowstoneTorchBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/GlowstoneWallTorchBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/GlowstoneWallTorchBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/MoonBerryBushBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/MoonBerryBushBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/ScorchedRockBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/ScorchedRockBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/UnlitLanternBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/UnlitLanternBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/UnlitTorchBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/UnlitTorchBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/UnlitWallTorchBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/UnlitWallTorchBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/environment/VaporSpoutBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/environment/VaporSpoutBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/machines/AdvancedSolarPanelBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/machines/AdvancedSolarPanelBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/machines/BasicSolarPanelBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/machines/BasicSolarPanelBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/machines/CoalGeneratorBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/machines/CoalGeneratorBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/machines/OxygenCollectorBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/machines/OxygenCollectorBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/machines/RefineryBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/machines/RefineryBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/special/SolarPanelPartBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/special/SolarPanelPartBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/special/aluminumwire/tier1/AluminumWireBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/special/aluminumwire/tier1/AluminumWireBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/special/aluminumwire/tier1/SealableAluminumWireBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/special/aluminumwire/tier1/SealableAluminumWireBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/special/fluidpipe/FluidPipeBlockEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/special/fluidpipe/FluidPipeBlockEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/special/fluidpipe/GlassFluidPipeBlock.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/special/fluidpipe/GlassFluidPipeBlock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/block/special/walkway/Walkway.java
+++ b/src/main/java/com/hrznstudio/galacticraft/block/special/walkway/Walkway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/AdvancedSolarPanelScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/AdvancedSolarPanelScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/BasicSolarPanelScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/BasicSolarPanelScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/BubbleDistributorScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/BubbleDistributorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/CircuitFabricatorScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/CircuitFabricatorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/CoalGeneratorScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/CoalGeneratorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/CompressorScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/CompressorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/ElectricArcFurnaceScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/ElectricArcFurnaceScreen.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.client.gui.screen.ingame;
 
 import com.hrznstudio.galacticraft.Constants;

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/ElectricCompressorScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/ElectricCompressorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/ElectricFurnaceScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/ElectricFurnaceScreen.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.client.gui.screen.ingame;
 
 import com.hrznstudio.galacticraft.Constants;

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/EnergyStorageModuleScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/EnergyStorageModuleScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/OxygenCollectorScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/OxygenCollectorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/OxygenCompressorScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/OxygenCompressorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/OxygenDecompressorScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/OxygenDecompressorScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/OxygenStorageModuleScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/OxygenStorageModuleScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/PlayerInventoryGCScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/PlayerInventoryGCScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/RefineryScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/RefineryScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/SpaceRaceScreen.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/screen/ingame/SpaceRaceScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/widget/SpaceRaceButtonWidget.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/widget/SpaceRaceButtonWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/widget/machine/AbstractWidget.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/widget/machine/AbstractWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/widget/machine/CapacitorWidget.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/widget/machine/CapacitorWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/widget/machine/FluidTankWidget.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/widget/machine/FluidTankWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/gui/widget/machine/OxygenTankWidget.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/gui/widget/machine/OxygenTankWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/model/GCGeneratedMachineModels.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/model/GCGeneratedMachineModels.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/model/entity/EvolvedCreeperEntityModel.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/model/entity/EvolvedCreeperEntityModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/model/entity/EvolvedSpiderModel.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/model/entity/EvolvedSpiderModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/model/entity/MoonVillagerEntityModel.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/model/entity/MoonVillagerEntityModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/network/GalacticraftC2SPackets.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/network/GalacticraftC2SPackets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/MoonSkyProperties.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/MoonSkyProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/block/entity/AdvancedSolarPanelBlockEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/block/entity/AdvancedSolarPanelBlockEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/block/entity/BasicSolarPanelBlockEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/block/entity/BasicSolarPanelBlockEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/block/entity/FluidPipeBlockEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/block/entity/FluidPipeBlockEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/block/entity/GalacticraftBlockEntityRenderers.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/block/entity/GalacticraftBlockEntityRenderers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/BubbleEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/BubbleEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedCreeperEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedCreeperEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedEvokerEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedEvokerEntityRenderer.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.client.render.entity;
 
 import com.hrznstudio.galacticraft.client.render.entity.feature.SpaceGearFeatureRenderer;

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedPillagerEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedPillagerEntityRenderer.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.client.render.entity;
 
 import com.hrznstudio.galacticraft.client.render.entity.feature.SpaceGearFeatureRenderer;

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedSkeletonEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedSkeletonEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedSpiderEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedSpiderEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedVindicatorEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedVindicatorEntityRenderer.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.client.render.entity;
 
 import com.hrznstudio.galacticraft.client.render.entity.feature.SpaceGearFeatureRenderer;

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedZombieRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/EvolvedZombieRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/MoonVillagerEntityRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/MoonVillagerEntityRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/feature/EvolvedCreeperChargeFeatureRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/feature/EvolvedCreeperChargeFeatureRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/feature/EvolvedSpiderEyesFeatureRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/feature/EvolvedSpiderEyesFeatureRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/render/entity/feature/SpaceGearFeatureRenderer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/render/entity/feature/SpaceGearFeatureRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/client/resource/GCResourceReloadListener.java
+++ b/src/main/java/com/hrznstudio/galacticraft/client/resource/GCResourceReloadListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/component/AutoSyncedItemTankComponent.java
+++ b/src/main/java/com/hrznstudio/galacticraft/component/AutoSyncedItemTankComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/component/GalacticraftComponents.java
+++ b/src/main/java/com/hrznstudio/galacticraft/component/GalacticraftComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/component/SubInventoryComponent.java
+++ b/src/main/java/com/hrznstudio/galacticraft/component/SubInventoryComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/component/SubTankComponent.java
+++ b/src/main/java/com/hrznstudio/galacticraft/component/SubTankComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/config/ConfigImpl.java
+++ b/src/main/java/com/hrznstudio/galacticraft/config/ConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/config/ConfigManagerImpl.java
+++ b/src/main/java/com/hrznstudio/galacticraft/config/ConfigManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/energy/GalacticraftEnergy.java
+++ b/src/main/java/com/hrznstudio/galacticraft/energy/GalacticraftEnergy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/entity/BubbleEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/BubbleEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedCreeperEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedCreeperEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedEvokerEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedEvokerEntity.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.entity;
 
 import net.minecraft.entity.EntityType;

--- a/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedPillagerEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedPillagerEntity.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.entity;
 
 import net.minecraft.entity.EntityType;

--- a/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedSkeletonEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedSkeletonEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedSpiderEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedSpiderEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedVindicatorEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedVindicatorEntity.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.entity;
 
 import net.minecraft.entity.EntityType;

--- a/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedZombieEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/EvolvedZombieEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/entity/GalacticraftBlockEntities.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/GalacticraftBlockEntities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/entity/GalacticraftEntityTypes.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/GalacticraftEntityTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/entity/MoonVillagerEntity.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/MoonVillagerEntity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/entity/damage/GalacticraftDamageSource.java
+++ b/src/main/java/com/hrznstudio/galacticraft/entity/damage/GalacticraftDamageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/fluids/CrudeOilFluid.java
+++ b/src/main/java/com/hrznstudio/galacticraft/fluids/CrudeOilFluid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/fluids/FuelFluid.java
+++ b/src/main/java/com/hrznstudio/galacticraft/fluids/FuelFluid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/fluids/GalacticraftFluids.java
+++ b/src/main/java/com/hrznstudio/galacticraft/fluids/GalacticraftFluids.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/fluids/OxygenFluid.java
+++ b/src/main/java/com/hrznstudio/galacticraft/fluids/OxygenFluid.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/hooks/ModMenuApiImpl.java
+++ b/src/main/java/com/hrznstudio/galacticraft/hooks/ModMenuApiImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/BatteryItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/BatteryItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/CannedFoodItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/CannedFoodItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/GCAccessories.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/GCAccessories.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/GalacticraftArmorMaterials.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/GalacticraftArmorMaterials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/GalacticraftFoodComponents.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/GalacticraftFoodComponents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/GalacticraftItems.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/GalacticraftItems.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/GalacticraftToolMaterials.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/GalacticraftToolMaterials.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/GenericLiquidCanister.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/GenericLiquidCanister.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/HotThrowableMeteorChunkItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/HotThrowableMeteorChunkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/InfiniteBatteryItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/InfiniteBatteryItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/OxygenGearItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/OxygenGearItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/OxygenMaskItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/OxygenMaskItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/OxygenTankItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/OxygenTankItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/SchematicItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/SchematicItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/StandardWrenchItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/StandardWrenchItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/ThermalArmorItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/ThermalArmorItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/items/ThrowableMeteorChunkItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/ThrowableMeteorChunkItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/loot/GalacticraftLootTables.java
+++ b/src/main/java/com/hrznstudio/galacticraft/loot/GalacticraftLootTables.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/misc/ForwardingDefaultList.java
+++ b/src/main/java/com/hrznstudio/galacticraft/misc/ForwardingDefaultList.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.misc;
 
 import net.minecraft.util.collection.DefaultedList;

--- a/src/main/java/com/hrznstudio/galacticraft/misc/TriFunction.java
+++ b/src/main/java/com/hrznstudio/galacticraft/misc/TriFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/misc/banner/GalacticraftBannerPatterns.java
+++ b/src/main/java/com/hrznstudio/galacticraft/misc/banner/GalacticraftBannerPatterns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/misc/capes/CapeLoader.java
+++ b/src/main/java/com/hrznstudio/galacticraft/misc/capes/CapeLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/misc/capes/JsonCapes.java
+++ b/src/main/java/com/hrznstudio/galacticraft/misc/capes/JsonCapes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/BaseFluidMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/BaseFluidMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/BiomeMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/BiomeMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/BlockStateProviderTypeAccessor.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/BlockStateProviderTypeAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/BuiltinBiomesAccessor.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/BuiltinBiomesAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/ChunkGeneratorAccessor.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/ChunkGeneratorAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/DimensionTypeMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/DimensionTypeMixin.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.mixin;
 
 import com.hrznstudio.galacticraft.Constants;

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/EntityMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/EntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/ItemStackMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/ItemStackMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/LanternBlockMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/LanternBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/LivingEntityMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/LivingEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/LootTablesAccessor.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/LootTablesAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/ServerWorldMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/ServerWorldMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/SkyPropertiesAccessor.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/SkyPropertiesAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/StructurePoolGeneratorMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/StructurePoolGeneratorMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/TorchBlockMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/TorchBlockMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/client/AbstractClientPlayerEntityMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/client/AbstractClientPlayerEntityMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/client/HandledScreenHooks.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/client/HandledScreenHooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/client/InGameHudMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/client/InGameHudMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/client/PauseMenuScreenMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/client/PauseMenuScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/client/PlayerInventoryScreenMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/client/PlayerInventoryScreenMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/mixin/client/WorldRendererMixin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/mixin/client/WorldRendererMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/network/GalacticraftS2CPackets.java
+++ b/src/main/java/com/hrznstudio/galacticraft/network/GalacticraftS2CPackets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/particle/GalacticraftParticles.java
+++ b/src/main/java/com/hrznstudio/galacticraft/particle/GalacticraftParticles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/particle/fluid/DrippingCrudeOilParticle.java
+++ b/src/main/java/com/hrznstudio/galacticraft/particle/fluid/DrippingCrudeOilParticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/particle/fluid/DrippingFuelParticle.java
+++ b/src/main/java/com/hrznstudio/galacticraft/particle/fluid/DrippingFuelParticle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/CompressingRecipe.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/CompressingRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/FabricationRecipe.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/FabricationRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/FabricationRecipeSerializer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/FabricationRecipeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/GalacticraftRecipes.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/GalacticraftRecipes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/ShapedCompressingRecipe.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/ShapedCompressingRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/ShapedCompressingRecipeSerializer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/ShapedCompressingRecipeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/ShapelessCompressingRecipe.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/ShapelessCompressingRecipe.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/ShapelessCompressingRecipeSerializer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/ShapelessCompressingRecipeSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultCompressingCategory.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultCompressingCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultCompressingDisplay.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultCompressingDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultFabricationCategory.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultFabricationCategory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultFabricationDisplay.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultFabricationDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultShapedCompressingDisplay.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultShapedCompressingDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultShapelessCompressingDisplay.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/rei/DefaultShapelessCompressingDisplay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/recipe/rei/GalacticraftREIPlugin.java
+++ b/src/main/java/com/hrznstudio/galacticraft/recipe/rei/GalacticraftREIPlugin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/AdvancedSolarPanelScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/AdvancedSolarPanelScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/BasicSolarPanelScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/BasicSolarPanelScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/BubbleDistributorScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/BubbleDistributorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/CircuitFabricatorScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/CircuitFabricatorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/CoalGeneratorScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/CoalGeneratorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/CompressorScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/CompressorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/ElectricArcFurnaceScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/ElectricArcFurnaceScreenHandler.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.screen;
 
 import com.hrznstudio.galacticraft.block.entity.ElectricArcFurnaceBlockEntity;

--- a/src/main/java/com/hrznstudio/galacticraft/screen/ElectricCompressorScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/ElectricCompressorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/ElectricFurnaceScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/ElectricFurnaceScreenHandler.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.screen;
 
 import com.hrznstudio.galacticraft.block.entity.ElectricFurnaceBlockEntity;

--- a/src/main/java/com/hrznstudio/galacticraft/screen/EnergyStorageModuleScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/EnergyStorageModuleScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/GalacticraftScreenHandlerTypes.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/GalacticraftScreenHandlerTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/MachineScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/MachineScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/OxygenCollectorScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/OxygenCollectorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/OxygenCompressorScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/OxygenCompressorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/OxygenDecompressorScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/OxygenDecompressorScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/OxygenStorageModuleScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/OxygenStorageModuleScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/PlayerInventoryGCScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/PlayerInventoryGCScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/RefineryScreenHandler.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/RefineryScreenHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/property/CapacitorProperty.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/property/CapacitorProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/property/FluidTankPropertyDelegate.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/property/FluidTankPropertyDelegate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/property/StatusProperty.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/property/StatusProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/slot/ChargeSlot.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/slot/ChargeSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/slot/FilteredSlot.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/slot/FilteredSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/slot/ItemSpecificSlot.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/slot/ItemSpecificSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/slot/OutputSlot.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/slot/OutputSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/slot/OxygenTankSlot.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/slot/OxygenTankSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/screen/slot/RecipeInputSlot.java
+++ b/src/main/java/com/hrznstudio/galacticraft/screen/slot/RecipeInputSlot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/server/command/GalacticraftCommands.java
+++ b/src/main/java/com/hrznstudio/galacticraft/server/command/GalacticraftCommands.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/sounds/GalacticraftSounds.java
+++ b/src/main/java/com/hrznstudio/galacticraft/sounds/GalacticraftSounds.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/structure/GalacticraftStructures.java
+++ b/src/main/java/com/hrznstudio/galacticraft/structure/GalacticraftStructures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/structure/MoonRuinsGenerator.java
+++ b/src/main/java/com/hrznstudio/galacticraft/structure/MoonRuinsGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/tag/GalacticraftTags.java
+++ b/src/main/java/com/hrznstudio/galacticraft/tag/GalacticraftTags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/util/ConnectingBlockUtils.java
+++ b/src/main/java/com/hrznstudio/galacticraft/util/ConnectingBlockUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/util/DrawableUtils.java
+++ b/src/main/java/com/hrznstudio/galacticraft/util/DrawableUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/util/EnergyUtils.java
+++ b/src/main/java/com/hrznstudio/galacticraft/util/EnergyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/util/OxygenUtils.java
+++ b/src/main/java/com/hrznstudio/galacticraft/util/OxygenUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/village/GalacticraftTradeOffers.java
+++ b/src/main/java/com/hrznstudio/galacticraft/village/GalacticraftTradeOffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/village/GalacticraftVillagerProfessions.java
+++ b/src/main/java/com/hrznstudio/galacticraft/village/GalacticraftVillagerProfessions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/village/MoonVillagerType.java
+++ b/src/main/java/com/hrznstudio/galacticraft/village/MoonVillagerType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/biome/GalacticraftBiomes.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/biome/GalacticraftBiomes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/biome/layer/MoonBiomeLayers.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/biome/layer/MoonBiomeLayers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/biome/layer/moon/MoonHighlandsBiomeLayer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/biome/layer/moon/MoonHighlandsBiomeLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/biome/layer/moon/MoonMareBiomeLayer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/biome/layer/moon/MoonMareBiomeLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/biome/layer/moon/MoonMergeLayer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/biome/layer/moon/MoonMergeLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/biome/layer/moon/ValleyCrossSamplingLayer.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/biome/layer/moon/ValleyCrossSamplingLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/biome/source/GalacticraftBiomeSources.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/biome/source/GalacticraftBiomeSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/biome/source/MoonBiomeSource.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/biome/source/MoonBiomeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/dimension/GalacticraftCelestialBodyTypes.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/dimension/GalacticraftCelestialBodyTypes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/dimension/GalacticraftDimensions.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/dimension/GalacticraftDimensions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/dimension/GalacticraftGases.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/dimension/GalacticraftGases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/carver/GalacticraftCarvers.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/carver/GalacticraftCarvers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/carver/LunarCaveCarver.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/carver/LunarCaveCarver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/chunk/MoonChunkGenerator.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/chunk/MoonChunkGenerator.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.world.gen.chunk;
 
 import com.hrznstudio.galacticraft.block.GalacticraftBlocks;

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/feature/GalacticraftFeatures.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/feature/GalacticraftFeatures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/feature/MoonPillagerBaseFeature.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/feature/MoonPillagerBaseFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -18,7 +18,6 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
  */
 
 package com.hrznstudio.galacticraft.world.gen.feature;

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/feature/MoonRuinsFeature.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/feature/MoonRuinsFeature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/spawner/EvolvedPillagerSpawner.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/spawner/EvolvedPillagerSpawner.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 package com.hrznstudio.galacticraft.world.gen.spawner;
 
 import com.hrznstudio.galacticraft.entity.GalacticraftEntityTypes;

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/stateprovider/MoonFloraBlockStateProvider.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/stateprovider/MoonFloraBlockStateProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/surfacebuilder/BlockStateWithChance.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/surfacebuilder/BlockStateWithChance.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/surfacebuilder/GalacticraftSurfaceBuilders.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/surfacebuilder/GalacticraftSurfaceBuilders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/surfacebuilder/MoonSurfaceBuilder.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/surfacebuilder/MoonSurfaceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/surfacebuilder/MultiBlockSurfaceBuilder.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/surfacebuilder/MultiBlockSurfaceBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/gen/surfacebuilder/MultiBlockSurfaceConfig.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/gen/surfacebuilder/MultiBlockSurfaceConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/main/java/com/hrznstudio/galacticraft/world/poi/GalacticraftPointOfInterestType.java
+++ b/src/main/java/com/hrznstudio/galacticraft/world/poi/GalacticraftPointOfInterestType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 HRZN LTD
+ * Copyright (c) 2019-2021 HRZN LTD
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updates copyright year from `2020` to `2019-2021` in:
* `LICENSE`
* `src/main/java/**.java`]
* `build.gradle`