### PR TITLE
fix: Make it compile on certain IDEs again

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ base {
 
 loom {
     refmapName = "galacticraft-rewoven.refmap.json"
-    accessWidener = File("src/main/resources/galacticraft_rewoven.accesswidener")
+    accessWidener = rootProject.file("src/main/resources/galacticraft_rewoven.accesswidener")
 }
 
 repositories {


### PR DESCRIPTION
For some reason sometimes plain `File("src/main/resources/galacticraft_rewoven.accesswidener")` will result in the file being searched in a random directory (I think it was `home/Geolykt/.gradle/deamon/6.8.3/src/main/resources/galacticraft_rewoven.accesswidener` for me)

(please ignore that I accidentally deleted the branch)