### PR TITLE
Fix: add model, glint for infinite oxygen tank

### DIFF
--- a/src/main/java/com/hrznstudio/galacticraft/items/GalacticraftItems.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/GalacticraftItems.java
@@ -196,7 +196,7 @@ public class GalacticraftItems {
     public static final Item SMALL_OXYGEN_TANK = registerItem(Constants.Items.SMALL_OXYGEN_TANK, new OxygenTankItem(new Item.Settings().group(ITEMS_GROUP).maxDamage(1620 * 10))); // 16200 ticks
     public static final Item MEDIUM_OXYGEN_TANK = registerItem(Constants.Items.MEDIUM_OXYGEN_TANK, new OxygenTankItem(new Item.Settings().group(ITEMS_GROUP).maxDamage(1620 * 20))); //32400 ticks
     public static final Item LARGE_OXYGEN_TANK = registerItem(Constants.Items.LARGE_OXYGEN_TANK, new OxygenTankItem(new Item.Settings().group(ITEMS_GROUP).maxDamage(1620 * 30))); //48600 ticks
-    public static final Item INFINITE_OXYGEN_TANK = registerItem(Constants.Items.INFINITE_OXYGEN_TANK, new OxygenTankItem(new Item.Settings().group(ITEMS_GROUP)));
+    public static final Item INFINITE_OXYGEN_TANK = registerItem(Constants.Items.INFINITE_OXYGEN_TANK, new InfiniteOxygenTankItem(new Item.Settings().group(ITEMS_GROUP)));
     public static final Item THERMAL_PADDING_HELMET = registerItem(Constants.Items.THERMAL_PADDING_HELMET, new ThermalArmorItem(new Item.Settings().group(ITEMS_GROUP), EquipmentSlot.HEAD));
     public static final Item THERMAL_PADDING_CHESTPIECE = registerItem(Constants.Items.THERMAL_PADDING_CHESTPIECE, new ThermalArmorItem(new Item.Settings().group(ITEMS_GROUP), EquipmentSlot.CHEST));
     public static final Item THERMAL_PADDING_LEGGINGS = registerItem(Constants.Items.THERMAL_PADDING_LEGGINGS, new ThermalArmorItem(new Item.Settings().group(ITEMS_GROUP), EquipmentSlot.LEGS));

--- a/src/main/java/com/hrznstudio/galacticraft/items/InfiniteOxygenTankItem.java
+++ b/src/main/java/com/hrznstudio/galacticraft/items/InfiniteOxygenTankItem.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019-2021 HRZN LTD
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.hrznstudio.galacticraft.items;
+
+import net.minecraft.item.ItemStack;
+
+/**
+ * @author <a href="https://github.com/StellarHorizons">StellarHorizons</a>
+ */
+public class InfiniteOxygenTankItem extends OxygenTankItem {
+    public InfiniteOxygenTankItem(Settings settings) {
+        super(settings);
+    }
+
+    @Override
+    public boolean hasGlint(ItemStack stack) {
+        return true;
+    }
+}

--- a/src/main/resources/assets/galacticraft-rewoven/models/item/infinite_oxygen_tank.json
+++ b/src/main/resources/assets/galacticraft-rewoven/models/item/infinite_oxygen_tank.json
@@ -1,0 +1,6 @@
+{
+  "parent": "item/generated",
+  "textures": {
+    "layer0": "galacticraft-rewoven:item/large_oxygen_tank"
+  }
+}


### PR DESCRIPTION
I believe this is not in another branch?
Fixes the infinite oxygen tank item model + adds enchantment glint.